### PR TITLE
A few updates

### DIFF
--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -104,3 +104,4 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -107,3 +107,4 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -53,8 +53,9 @@ light:
     pin:
       inverted: true
       number: GPIO16
-      
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -58,8 +58,9 @@ light:
     pin:
       inverted: true
       number: GPIO16
-      
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -67,8 +67,9 @@ light:
     pin:
       inverted: true
       number: GPIO2
-      
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -100,3 +100,4 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -57,7 +57,7 @@ switch:
   - platform: restart
     id: restart_switch
     name: "${friendly_name} Restart"
-    
+
 
 output:
   - platform: esp8266_pwm
@@ -80,8 +80,9 @@ light:
     green: green_output
     blue: blue_output
 
-    
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -34,7 +34,6 @@ binary_sensor:
   - platform: gpio
     pin:
       number: 0
-      mode: INPUT_PULLUP
       inverted: true
     name: "${friendly_name} Button"
     disabled_by_default: true

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -70,8 +70,9 @@ light:
     cold_white_color_temperature: 153 mireds
     warm_white_color_temperature: 500 mireds
     color_interlock: true
-    
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -69,8 +69,9 @@ light:
     cold_white_color_temperature: 6000 K
     warm_white_color_temperature: 3000 K
     color_interlock: true
-    
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -111,25 +111,20 @@ switch:
     name: "${friendly_name} Restart"
 
   - platform: gpio
-    id: blue_led
-    pin:
-      number: GPIO13
-      inverted: true
-      
-  - platform: gpio
     name: "${friendly_name}"
     pin: GPIO14
     id: relay
     restore_mode: RESTORE_DEFAULT_ON
     on_turn_on:
-      - switch.turn_on: blue_led
+      - light.turn_on: blue_led
 
     on_turn_off:
-      - switch.turn_off: blue_led
+      - light.turn_off: blue_led
 
 light:
   - platform: status_led
     name: "${friendly_name} Status LED"
+    id: blue_led
     disabled_by_default: true
     pin:
       inverted: true
@@ -137,8 +132,9 @@ light:
 
 time:
   - platform: sntp
-  
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -96,8 +96,9 @@ light:
     id: led1
     output: button_led1
     default_transition_length: 500ms
-    
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -127,8 +127,9 @@ light:
     id: light4
     output: led2
     default_transition_length: 500ms
-    
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -158,9 +158,10 @@ light:
     id: led3
     output: button_led3
     default_transition_length: 500ms
-    
-    
+
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -129,8 +129,9 @@ light:
     name: "${friendly_name} Light 4"
     id: light4
     output: relay4
-    
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -65,8 +65,9 @@ light:
     effects:
       - addressable_rainbow:
       - addressable_scan:
-      
+
 text_sensor:
   - platform: wifi_info
     ip_address:
       name: "${friendly_name} IP Address"
+      disabled_by_default: true


### PR DESCRIPTION
- GPIO0 always needs an external pullup and ESPHome dev enforces this with esphome/esphome#2303
- Disabling the IP address sensor by default (Users can enable via HA easily if needed, but just cuts down on extra entities that not everyone needs :smile_cat:)
- Utilize the `status_led` light in the smart plugs instead of making a switch on the same GPIO pin. 