### PR TITLE
Add dashboard import url information for easy adoption by users

### DIFF
--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-garage-door"
+  name: "athom-garage-door"
   friendly_name: "Athom Garage Door"
   project_name: "athom.garage-door"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-garage-door.yaml
 
 sensor:
   - platform: uptime

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-mini-switch"
+  name: "athom-mini-switch"
   friendly_name: "Athom Mini Switch"
   project_name: "athom.mini-switch"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {}
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-mini-switch.yaml
 
 switch:
   - platform: restart

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-relay-board-x1"
+  name: "athom-relay-board-x1"
   friendly_name: "Athom Relay Board x1"
   project_name: "athom.relay-board-x1"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-relay-board-x1.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-relay-board-x2"
+  name: "athom-relay-board-x2"
   friendly_name: "Athom Relay Board x2"
   project_name: "athom.relay-board-x2"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-relay-board-x2.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-relay-board-x4"
+  name: "athom-relay-board-x4"
   friendly_name: "Athom Relay Board x4"
   project_name: "athom.relay-board-x4"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-relay-board-x4.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-relay-board-x8"
+  name: "athom-relay-board-x8"
   friendly_name: "Athom Relay Board x8"
   project_name: "athom.relay-board-x8"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-relay-board-x8.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-rgb-light"
+  name: "athom-rgb-light"
   friendly_name: "Athom RGB Light Strip"
   project_name: "athom.rgb-light"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-rgb-light.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-rgbct-light"
+  name: "athom-rgbct-light"
   friendly_name: "Athom RGBCT Light"
   project_name: "athom.rgbct-light"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-rgbct-light.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-rgbww-light"
+  name: "athom-rgbww-light"
   friendly_name: "Athom RGBWW Light"
   project_name: "athom.rgbww-light"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-rgbww-light.ymal
 
 binary_sensor:
   - platform: status

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-smart-plug"
+  name: "athom-smart-plug"
   friendly_name: "Athom Smart Plug"
   project_name: "athom.smart-plug"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -26,6 +26,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-smart-plug.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-sw01"
+  name: "athom-sw01"
   friendly_name: "Athom SW01"
   project_name: "athom.sw01"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -27,6 +27,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-sw01.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-sw02"
+  name: "athom-sw02"
   friendly_name: "Athom SW02"
   project_name: "athom.sw02"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -27,6 +27,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-sw02.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-sw03"
+  name: "athom-sw03"
   friendly_name: "Athom SW03"
   project_name: "athom.sw03"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -27,6 +27,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-sw03.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -1,11 +1,11 @@
 substitutions:
-  device_name: "athom-sw04"
+  name: "athom-sw04"
   friendly_name: "Athom SW04"
   project_name: "athom.sw04"
   project_version: "1.0"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp8285
@@ -27,6 +27,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-sw04.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -1,12 +1,12 @@
 substitutions:
-  device_name: "athom-ws2812b"
+  name: "athom-ws2812b"
   friendly_name: "Athom WS2812B"
   project_name: "athom.ws2812b"
   project_version: "1.0"
   button_toggle: "true"
 
 esphome:
-  name: "${device_name}"
+  name: "${name}"
   name_add_mac_suffix: true
   platform: ESP8266
   board: esp01_1m
@@ -27,6 +27,9 @@ wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
+
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-ws2812b.yaml
 
 binary_sensor:
   - platform: status


### PR DESCRIPTION
@tarontop
Hey Aiden, Here are some updates to add easy adoption by users in the ESPHome dashboard. I have changed the `device_name` substitution to `name` which also allows this process to be a bit easier.