### PR TITLE
A few updates

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -54,7 +54,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 button:

--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -27,6 +27,9 @@ wifi:
 
 captive_portal:
 
+dashboard_import:
+  package_import_url: github://athom-tech/athom-configs/athom-cb02.yaml
+
 binary_sensor:
   - platform: status
     name: "${friendly_name} Status"

--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -55,8 +55,7 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
-
-
+    disabled_by_default: true
 
 switch:
   - platform: restart
@@ -82,9 +81,6 @@ light:
     pin:
       inverted: true
       number: GPIO4
-
-time:
-  - platform: sntp
 
 text_sensor:
   - platform: wifi_info

--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -50,18 +50,19 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
 
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
     disabled_by_default: true
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
+switch:
   - platform: gpio
     name: "${friendly_name}"
     pin: GPIO13

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -62,17 +62,18 @@ binary_sensor:
           - ON for at most 1s
           - OFF for at least 0.2s
         then:
-          switch.turn_on: relay
+          - switch.turn_on: relay
       - timing:
           - ON for at least 4s
         then:
-          switch.turn_on: restart_switch
+          - button.press: restart_button
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
+switch:
   - platform: gpio
     pin: GPIO5
     name: "${friendly_name} Relay"

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -32,7 +32,7 @@ dashboard_import:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 binary_sensor:

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -56,7 +56,7 @@ light:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 binary_sensor:

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -30,9 +30,9 @@ captive_portal:
 dashboard_import:
   package_import_url: github://athom-tech/athom-configs/athom-mini-switch.yaml
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 output:
@@ -82,7 +82,7 @@ binary_sensor:
           - ON for at most 0.5s
           - OFF for at most 0.5s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
 
   # Button on mini switch
   - platform: gpio
@@ -101,7 +101,7 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
 
   - platform: status
     name: "${friendly_name} Status"

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -38,11 +38,12 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
+switch:
   # Relay
   - platform: gpio
     name: "${friendly_name}"

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -36,7 +36,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
 
 switch:
   - platform: restart

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -38,11 +38,12 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
+switch:
   # Relay
   - platform: gpio
     name: "${friendly_name} - 1"

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -36,7 +36,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
 
 switch:
   - platform: restart

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -36,7 +36,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 button:

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -37,12 +37,14 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+    disabled_by_default: true
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
+switch:
   - platform: gpio
     name: "${friendly_name} - 1"
     pin: GPIO16
@@ -70,7 +72,7 @@ light:
     pin:
       inverted: true
       number: GPIO5
-      
+
 text_sensor:
   - platform: wifi_info
     ip_address:

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -45,12 +45,14 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+    disabled_by_default: true
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
+switch:
   - platform: gpio
     name: "${friendly_name} - 1"
     pin: GPIO16

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -44,7 +44,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 button:

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -50,17 +50,16 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
 
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
-
 
 output:
   - platform: esp8266_pwm
@@ -73,8 +72,6 @@ output:
     id: blue_output
     pin: GPIO14
 
-
-
 light:
   - platform: rgb
     name: "${friendly_name}"
@@ -82,7 +79,6 @@ light:
     red: red_output
     green: green_output
     blue: blue_output
-
 
 text_sensor:
   - platform: wifi_info

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -54,7 +54,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
 
 button:
   - platform: restart

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -38,9 +38,9 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 output:

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -36,7 +36,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
 
 switch:
   - platform: restart

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -28,7 +28,7 @@ wifi:
 captive_portal:
 
 dashboard_import:
-  package_import_url: github://athom-tech/athom-configs/athom-rgbww-light.ymal
+  package_import_url: github://athom-tech/athom-configs/athom-rgbww-light.yaml
 
 binary_sensor:
   - platform: status

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -38,9 +38,9 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 output:

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -36,7 +36,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
 
 switch:
   - platform: restart

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -50,11 +50,12 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
 
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+    disabled_by_default: true
 
   - platform: hlw8012
     sel_pin:
@@ -108,11 +109,12 @@ sensor:
       - multiply: 0.001
 
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
+switch:
   - platform: gpio
     name: "${friendly_name}"
     pin: GPIO14

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -54,7 +54,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
   - platform: hlw8012

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -51,15 +51,16 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
 
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+    disabled_by_default: true
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 output:

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -55,7 +55,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 button:

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -51,7 +51,7 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
   - platform: gpio
     pin:
       inverted: true
@@ -66,10 +66,11 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+    disabled_by_default: true
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 output:

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -65,7 +65,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 button:

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -51,7 +51,7 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
   - platform: gpio
     pin:
       inverted: true
@@ -76,10 +76,11 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+    disabled_by_default: true
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 output:

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -75,7 +75,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
     disabled_by_default: true
 
 button:

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -51,7 +51,7 @@ binary_sensor:
       - timing:
           - ON for at least 4s
         then:
-          - switch.turn_on: restart_switch
+          - button.press: restart_button
   - platform: gpio
     pin:
       inverted: true
@@ -87,9 +87,9 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 output:

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -85,7 +85,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
 
 button:
   - platform: restart

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -52,9 +52,9 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
-switch:
+button:
   - platform: restart
-    id: restart_switch
+    id: restart_button
     name: "${friendly_name} Restart"
 
 light:

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -50,7 +50,7 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "${friendly_name} Uptime Sensor"
+    name: "${friendly_name} Uptime"
 
 switch:
   - platform: restart


### PR DESCRIPTION
- Renames `sensor.{name}_uptime_sensor` to `sensor.{name}_uptime`
- Changes from restart `switch` to new restart `button`
- Sets uptime sensor as disabled by default
- dashboard import url for CB02