### PR TITLE
Update athom-smart-plug.yaml

### DIFF
--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -63,21 +63,12 @@ sensor:
       inverted: True
     cf_pin: GPIO4
     cf1_pin: GPIO5
-    voltage_divider: 780
+    voltage_divider: 1720
+    model: BL0937
+
     current:
       name: "${friendly_name} Current"
-      filters:
-          - calibrate_linear:
-            - 0.0000 -> 0.0110 # Relay off no load
-            - 0.0097 -> 0.0260 # Relay on no load
-            - 0.9270 -> 0.7570
-            - 2.0133 -> 1.6330
-            - 2.9307 -> 2.3750
-            - 5.4848 -> 4.4210
-            - 8.4308 -> 6.8330
-            - 9.9171 -> 7.9830
-          # Normalize for plug load
-          - lambda: if (x < 0.0260) return 0; else return (x - 0.0260);
+
     voltage:
       name: "${friendly_name} Voltage"
 
@@ -85,18 +76,7 @@ sensor:
       name: "${friendly_name} Power"
       id: socket_my_power
       unit_of_measurement: W
-      filters:
-          - calibrate_linear:
-            - 0.0000 -> 0.5900 # Relay off no load
-            - 0.0000 -> 1.5600 # Relay on no load
-            - 198.5129 -> 87.8300
-            - 434.2469 -> 189.5000
-            - 628.6241 -> 273.9000
-            - 1067.0067 -> 460.1000
-            - 1619.8098 -> 699.2000
-            - 2043.0282 -> 885.0000
-          # Normalize for plug load
-          - lambda: if (x < 1.5600) return 0; else return (x - 1.5600);
+
     change_mode_every: 1
     update_interval: 5s
 


### PR DESCRIPTION
It seems that the actual chip used en PG03 is not HLW8012 but BL0937. I haven't open the plug, but it is apparent from the readings.
In that case, using the new `model` option, the multipliers are correctly computed and no linear filter is needed.
This way all measures are correct, while the current implementation shows an incorrect `energy` if it is used directly (instead of the integration).
I calculated the voltage multiplier empirically. You could provide the actual resistors value.