### PR TITLE
Enable flash restore on smart plug

### DIFF
--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -14,7 +14,6 @@ esphome:
 esp8266:
   board: esp8285
   restore_from_flash: true
-  board_flash_mode: dout
 
 api:
 

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -7,11 +7,14 @@ substitutions:
 esphome:
   name: "${name}"
   name_add_mac_suffix: true
-  platform: ESP8266
-  board: esp8285
   project:
     name: "${project_name}"
     version: "${project_version}"
+
+esp8266:
+  board: esp8285
+  restore_from_flash: true
+  board_flash_mode: dout
 
 api:
 
@@ -101,10 +104,12 @@ sensor:
     update_interval: 5s
 
   - platform: total_daily_energy
-    name: "${friendly_name} Total Daily Energy"
+    name: "${friendly_name} Total Energy"
     power_id: socket_my_power
     unit_of_measurement: kWh
     accuracy_decimals: 3
+    restore: true
+    min_save_interval: 180s
     filters:
       - multiply: 0.001
 


### PR DESCRIPTION
Enables restoring the previous state from flash.  So after a power outage, the smart plug now remembers it's previous state, and the energy counter no longer resets.