### PR TITLE
athom-sw02-v2: Make restore mode configureable with substitution

### DIFF
--- a/athom-sw02_v2.yaml
+++ b/athom-sw02_v2.yaml
@@ -3,6 +3,8 @@ substitutions:
   friendly_name: "Athom SW02"
   project_name: "athom.sw02"
   project_version: "1.0"
+  light1_restore_mode: RESTORE_DEFAULT_OFF
+  light2_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
@@ -105,6 +107,7 @@ light:
     name: "${friendly_name} Light 1"
     id: light1
     output: relay1
+    restore_mode: ${light1_restore_mode}
     on_turn_on:
       - light.turn_on: light3
     on_turn_off:
@@ -113,6 +116,7 @@ light:
     name: "${friendly_name} Light 2"
     id: light2
     output: relay2
+    restore_mode: ${light2_restore_mode}
     on_turn_on:
       - light.turn_on: light4
     on_turn_off:


### PR DESCRIPTION
Hello,

as one of my devices need permanent power (Hue Lamps) I'm in need of having the restore-mode configurable. As I haven't found an approach to override the sensors (because existing ids would conflict) I would like to add this option to like in first version of atom-sw2 config to be able to keep using the config as package and have easy access to config-updates :)

Thanks 👍🏻 

