### PR TITLE
Update athom-smart-plug-v2.yaml

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -12,6 +12,9 @@ esphome:
     name: "${project_name}"
     version: "${project_version}"
 
+preferences:
+  flash_write_interval: 180secs
+  
 esp8266:
   board: esp8285
   restore_from_flash: true
@@ -94,7 +97,6 @@ sensor:
   - platform: total_daily_energy
     name: "${friendly_name} Total Daily Energy"
     restore: true
-    min_save_interval: 180s
     power_id: power_sensor
     unit_of_measurement: kWh
     accuracy_decimals: 3


### PR DESCRIPTION
Removed min_save_interval: 180s as breaking change in total_daily_energy in ESPhome 2022.8.0
Added preference and flash_write_interval to replace it