### PR TITLE
Update athom-smart-plug.yaml

### DIFF
--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -16,6 +16,9 @@ esp8266:
   board: esp8285
   restore_from_flash: true
 
+preferences:
+  flash_write_interval: 180sec
+  
 api:
 
 ota:
@@ -109,7 +112,6 @@ sensor:
     unit_of_measurement: kWh
     accuracy_decimals: 3
     restore: true
-    min_save_interval: 180s
     filters:
       - multiply: 0.001
 


### PR DESCRIPTION
Removed min_save_interval: 180s as breaking change in total_daily_energy in ESPhome 2022.8.0
Added preference and flash_write_interval to replace it