### PR TITLE
Update athom-rgbww-light.yaml

### DIFF
--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -66,18 +66,28 @@ output:
   - platform: esp8266_pwm
     id: red_output
     pin: GPIO4
+    min_power: 0.000499
+    max_power: 1
   - platform: esp8266_pwm
     id: green_output
     pin: GPIO12
+    min_power: 0.000499
+    max_power: 1
   - platform: esp8266_pwm
     id: blue_output
     pin: GPIO14
+    min_power: 0.000499
+    max_power: 1
   - platform: esp8266_pwm
     id: warm_white_output
     pin: GPIO13
+    min_power: 0.000499
+    max_power: 1
   - platform: esp8266_pwm
     id: white_output
     pin: GPIO5
+    min_power: 0.000499
+    max_power: 1
 
 
 light:


### PR DESCRIPTION
Added min_power and max_power to each output with required values. This prevents leds from turning off when below 7% brightness in Home Assistant