### PR TITLE
[rgbct] Don't turn off the lights at very low brightness values

### DIFF
--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -66,15 +66,27 @@ output:
   - platform: esp8266_pwm
     id: red_output
     pin: GPIO4
+    min_power: 0.000499
+    max_power: 1
+    zero_means_zero: true
   - platform: esp8266_pwm
     id: green_output
     pin: GPIO12
+    min_power: 0.000499
+    max_power: 1
+    zero_means_zero: true
   - platform: esp8266_pwm
     id: blue_output
     pin: GPIO14
+    min_power: 0.000499
+    max_power: 1
+    zero_means_zero: true
   - platform: esp8266_pwm
     id: white_output
     pin: GPIO5
+    min_power: 0.01
+    max_power: 1
+    zero_means_zero: true
   - platform: esp8266_pwm
     id: ct_output
     inverted: true


### PR DESCRIPTION
Based on #23 

I suspect other lights need this as well, but I don't have others to test.

Note that the white modes shut off at around 15% brightness, vs 7% for the colors, hence the higher min_power value.