### PR TITLE
https://esphome.io/changelog/2023.2.0.html

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -1,6 +1,5 @@
 substitutions:
   device_name: "athom-smart-plug-v2"
-  friendly_name: "Athom Smart Plug V2"
   project_name: "athom.smart-plug-v2"
   project_version: "1.1"
   relay_restore_mode: RESTORE_DEFAULT_OFF
@@ -8,6 +7,7 @@ substitutions:
 esphome:
   name: "${device_name}"
   name_add_mac_suffix: true
+  friendly_name: "Athom Smart Plug V2"
   project:
     name: "${project_name}"
     version: "${project_version}"


### PR DESCRIPTION
Friendly Name
ESPHome now supports setting a friendly_name which is sent to Home Assistant. This name will be used for the config entry, the device name, and will be automatically prefixed to all of the entities where needed by Home Assistant.

Note
If you opt to use this new friendly name, take note that you should remove any friendly name (substitition) that you currently prepend onto entity name in YAML.
```yaml
esphome:
  name: living-room
  friendly_name: Living Room

sensor:
  - platform: dht
    pin: GPIO5
    name: Temperature
```
What would be the best way of handling this?
Edit: Setting the friendly_name in the esphome: section **prefixes** the device name.
Then creating a long display name that is not shown on mobile home assistant app.