### PR TITLE
Update athom-smart-plug-v2.yaml

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -131,11 +131,11 @@ sensor:
 
 button:
   - platform: factory_reset
-    name: "Restart with Factory Default Settings"
+    name: "${friendly_name} Restart with Factory Default Settings"
     id: Reset
     
   - platform: safe_mode
-    name: "Safe Mode"
+    name: "${friendly_name} Safe Mode"
     internal: false
 
 switch:
@@ -157,11 +157,11 @@ light:
 text_sensor:
   - platform: wifi_info
     ip_address:
-      name: "IP Address"
+      name: "${friendly_name} IP Address"
     ssid:
-      name: "Connected SSID"
+      name: "${friendly_name} Connected SSID"
     mac_address:
-      name: "Mac Address"
+      name: "${friendly_name} MAC Address"
      
 time:
   - platform: sntp


### PR DESCRIPTION
Added ${friendly_name} to:
- Restart with Factory Defaults
- Safe Mode
- Connected SSID
- IP Address
- Mac Address

As these all have generic names in Home Assistant due to the lack of prefix, so end up with Entity IDs of sensor.ip_address, sensor.ip_address2, sensor.ip_address3, sensor.ip_address4, etc.

Also changed "Mac" to "MAC" (as it is an acronym, so should be in capitals).