### PR TITLE
Update athom-presence-sensor.yaml

### DIFF
--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -148,7 +148,7 @@ switch:
     internal: true
     entity_category: config
     optimistic: true
-    restore_state: false
+    restore_mode: false
     turn_on_action:
       - uart.write: "sensorStart\r\n"
     turn_off_action:


### PR DESCRIPTION
Correct failed config for esphome 2023.07

Example error code below:
switch.template: [source /config/esphome/.esphome/packages/43f53298/athom-presence-sensor.yaml:145]
  platform: template
  name: mmWave Status
  id: mmwave_sensor
  internal: True
  entity_category: config
  optimistic: True
  
  The restore_state option has been removed in 2023.7.0. Use the restore_mode option instead.
  restore_state: False
  turn_on_action: 
    - uart.write: sensorStart
      
  turn_off_action: 
    - uart.write: sensorStop