### PR TITLE
"restore_state" deprecated, instead use "restore_mode"

### DIFF
--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -148,7 +148,7 @@ switch:
     internal: true
     entity_category: config
     optimistic: true
-    restore_state: false
+    # restore_state: false
     turn_on_action:
       - uart.write: "sensorStart\r\n"
     turn_off_action:


### PR DESCRIPTION
Line 151 "restore_state: false". As this is not used and "restore_state" is "false" anyway - Propose remove it completely.