### PR TITLE
Add WiFi signal sensor to all devices

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -63,6 +63,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
@@ -94,7 +98,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -36,6 +36,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 binary_sensor:
   - platform: status
     name: "${friendly_name} Status"
@@ -120,7 +124,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-ls-4p-3wire.yaml
+++ b/athom-ls-4p-3wire.yaml
@@ -69,6 +69,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
@@ -97,7 +101,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-ls-4p-4wire.yaml
+++ b/athom-ls-4p-4wire.yaml
@@ -68,6 +68,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
@@ -97,7 +101,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -66,6 +66,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 binary_sensor:
   # Wired switch
   - platform: gpio
@@ -117,7 +121,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -41,6 +41,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: restart
     id: restart_button

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -42,6 +42,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: restart
     id: restart_button

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -45,6 +45,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: restart
     id: restart_button

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -57,6 +57,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: restart
     id: restart_button

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -66,6 +66,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -11,7 +11,7 @@ globals:
     type: int
     restore_value: yes
     initial_value: '0'
-    
+
 esphome:
   name: "${name}"
   name_add_mac_suffix: true
@@ -28,7 +28,7 @@ esp8266:
 
 preferences:
   flash_write_interval: 1min
-  
+
 api:
 
 ota:
@@ -56,6 +56,10 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
 button:
   - platform: factory_reset

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -35,7 +35,7 @@ captive_portal:
 
 dashboard_import:
   package_import_url: github://athom-tech/athom-configs/athom-rgbw-light.yaml
-  
+
 binary_sensor:
   - platform: status
     name: "${friendly_name} Status"
@@ -62,28 +62,32 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
     id: Reset
-            
+
 output:
   - platform: esp8266_pwm
     id: output_red
     pin: GPIO4
-    
+
   - platform: esp8266_pwm
     id: output_green
     pin: GPIO12
-    
+
   - platform: esp8266_pwm
     id: output_blue
     pin: GPIO14
-    
+
   - platform: esp8266_pwm
     id: output_white
     pin: GPIO13
-    
+
 light:
   - platform: rgbw
     name: "${friendly_name}"
@@ -94,7 +98,7 @@ light:
     white: output_white
     color_interlock: true
 
-    
+
 text_sensor:
   - platform: wifi_info
     ip_address:

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -28,7 +28,7 @@ esp8266:
 
 preferences:
   flash_write_interval: 1min
-  
+
 api:
 
 ota:
@@ -56,6 +56,10 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
 button:
   - platform: factory_reset

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -18,7 +18,7 @@ esp8266:
 
 preferences:
   flash_write_interval: 1min
-  
+
 api:
 
 ota:
@@ -48,7 +48,7 @@ globals:
   - id: total_energy
     type: float
     restore_value: yes
-    initial_value: '0.0' 
+    initial_value: '0.0'
 
 binary_sensor:
   - platform: status
@@ -75,6 +75,10 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
   - platform: cse7766
     update_interval: 10s
@@ -133,7 +137,7 @@ button:
   - platform: factory_reset
     name: "Restart with Factory Default Settings"
     id: Reset
-    
+
   - platform: safe_mode
     name: "Safe Mode"
     internal: false
@@ -162,7 +166,7 @@ text_sensor:
       name: "Connected SSID"
     mac_address:
       name: "Mac Address"
-     
+
 time:
   - platform: sntp
     id: sntp_time

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -18,7 +18,7 @@ esp8266:
 
 preferences:
   flash_write_interval: 1min
-  
+
 api:
 
 ota:
@@ -62,6 +62,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
     disabled_by_default: true
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
   - platform: hlw8012
     sel_pin:
@@ -147,7 +151,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
- 
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -15,7 +15,7 @@ esphome:
 esp8266:
   board: esp8285
   restore_from_flash: true
-  
+
 preferences:
   flash_write_interval: 1min
 
@@ -70,6 +70,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
@@ -119,7 +123,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -18,7 +18,7 @@ esp8266:
 
 preferences:
   flash_write_interval: 1min
-  
+
 api:
 
 ota:
@@ -70,6 +70,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
@@ -119,7 +123,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -65,7 +65,7 @@ binary_sensor:
           - ON for at least 4s
         then:
           - button.press: Reset
-          
+
   - platform: gpio
     pin:
       inverted: true
@@ -84,6 +84,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
@@ -97,7 +101,7 @@ output:
   - platform: gpio
     pin: GPIO4
     id: relay2
-    
+
   # - platform: gpio
   #   pin: GPIO16
   #   id: io16
@@ -162,7 +166,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -84,6 +84,10 @@ sensor:
     name: "${friendly_name} Uptime"
     disabled_by_default: true
 
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
 button:
   - platform: factory_reset
     name: Restart with Factory Default Settings
@@ -155,7 +159,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -66,7 +66,7 @@ binary_sensor:
           - ON for at least 4s
         then:
           - button.press: Reset
-          
+
   - platform: gpio
     pin:
       inverted: true
@@ -98,6 +98,10 @@ sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
     disabled_by_default: true
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
 button:
   - platform: factory_reset
@@ -193,7 +197,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -64,7 +64,7 @@ binary_sensor:
           - ON for at least 4s
         then:
           - button.press: Reset
-          
+
   - platform: gpio
     pin:
       inverted: true
@@ -99,6 +99,10 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
 button:
   - platform: factory_reset
@@ -155,7 +159,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -18,7 +18,7 @@ esp8266:
 
 preferences:
   flash_write_interval: 1min
-  
+
 api:
 
 ota:
@@ -48,7 +48,7 @@ globals:
   - id: total_energy
     type: float
     restore_value: yes
-    initial_value: '0.0' 
+    initial_value: '0.0'
 
 binary_sensor:
   - platform: status
@@ -75,6 +75,10 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime Sensor"
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
   - platform: cse7766
     update_interval: 10s
@@ -159,7 +163,7 @@ text_sensor:
     ip_address:
       name: "${friendly_name} IP Address"
       disabled_by_default: true
-     
+
 time:
   - platform: sntp
     id: my_time

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -21,10 +21,10 @@ esp8266:
   restore_from_flash: true
   framework:
     version: 2.7.4
-  
+
 preferences:
   flash_write_interval: 1min
-    
+
 api:
 
 ota:
@@ -72,6 +72,10 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "${friendly_name} Uptime"
+
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
 
 button:
   - platform: factory_reset


### PR DESCRIPTION
Added a [WiFi signal strength component](https://esphome.io/components/sensor/wifi_signal) to all devices, similar to what the [presence sensor](https://github.com/athom-tech/athom-configs/blob/ff3d935dab48e17c5485d04a489b66f449f882f7/athom-presence-sensor.yaml#L139) already had.