### PR TITLE
Add missing IDs to Presence sensor config

### DIFF
--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -135,15 +135,18 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "Uptime Sensor"
+    id: "uptime"
 
   - platform: wifi_signal
     name: "WiFi Signal Sensor"
     update_interval: 60s
+    id: "wifi_signal"
 
   - platform: bh1750
     name: "Light Sensor"
     address: 0x23
     update_interval: 5s
+    id: "light_sensor"
 
 switch:
   - platform: template

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -135,12 +135,12 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "Uptime Sensor"
-    id: "uptime"
+    id: "uptime_sensor"
 
   - platform: wifi_signal
     name: "WiFi Signal Sensor"
     update_interval: 60s
-    id: "wifi_signal"
+    id: "wifi_signal_sensor"
 
   - platform: bh1750
     name: "Light Sensor"


### PR DESCRIPTION
Add missing ID's so that the sensors can be extended.

Sensors update a lot more often than I want to see in Home Assistant and this is an example of how it would be useful to extend them to slow down the updates when changes are very small.
```
sensor:
  - id: !extend "light_sensor"
    filters:
      - or:
        - throttle: 10min
        - delta: 3.0
  - id: !extend "uptime_sensor"
    update_interval: 60min
  - id: !extend "wifi_signal_sensor"
    filters:
      - or:
        - throttle: 60min
        - delta: 3.0
 ```