### PR TITLE
Removed update_interval from platform: cse7766 - athom-smart-plug-v2.yaml

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -84,7 +84,6 @@ sensor:
     update_interval: 60s
 
   - platform: cse7766
-    update_interval: 10s
     current:
       name: "Current"
       filters:


### PR DESCRIPTION
Removed update_interval from platform: cse7766 due ESPHome braking change 

https://github.com/esphome/esphome/pull/6095