### PR TITLE
Update athom-smart-plug-v2.yaml to replace invalid update_interval

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -84,20 +84,23 @@ sensor:
     update_interval: 60s
 
   - platform: cse7766
-    update_interval: 10s
     current:
       name: "Current"
       filters:
-          - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
+        - throttle_average: 10s
+        - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
 
 
     voltage:
       name: "Voltage"
+      filters:
+        - throttle_average: 10s
     power:
       name: "Power"
       id: power_sensor
       filters:
-          - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
+        - throttle_average: 10s
+        - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
 
 
     energy:
@@ -105,6 +108,7 @@ sensor:
       id: energy
       unit_of_measurement: kWh
       filters:
+        - throttle_average: 10s
         # Multiplication factor from W to kW is 0.001
         - multiply: 0.001
       on_value:


### PR DESCRIPTION
Remove "update_interval" from cse7766 section, which prevents code from compiling in 2024.2.0, and replace with a throttle_average filter for each sensor within this group.