### PR TITLE
Update athom-smart-plug-v2.yaml to Categorize Config/Diag in HA and add meaningful WiFi, Uptime and Last Restarted sensors

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -37,8 +37,6 @@ web_server:
   port: 80
 
 wifi:
-  # Directly connects to WiFi network without doing a full scan first
-  fast_connect: true
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -37,6 +37,8 @@ web_server:
   port: 80
 
 wifi:
+  # Directly connects to WiFi network without doing a full scan first
+  fast_connect: true
   ap: {} # This spawns an AP with the device name and mac address with no password.
 
 captive_portal:
@@ -57,6 +59,7 @@ globals:
 binary_sensor:
   - platform: status
     name: "Status"
+    entity_category: diagnostic    
 
   - platform: gpio
     pin:
@@ -79,10 +82,26 @@ binary_sensor:
 sensor:
   - platform: uptime
     name: "Uptime Sensor"
+    id: uptime_sensor
+    entity_category: diagnostic
+    internal: True
 
   - platform: wifi_signal
     name: "WiFi Signal"
+    id: wifi_signal_db
     update_interval: 60s
+    entity_category: diagnostic
+    internal: true
+
+  # Reports the WiFi signal strength in %
+  - platform: copy
+    source_id: wifi_signal_db
+    name: "WiFi Strength"
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "%"
+    entity_category: diagnostic
+
 
   - platform: cse7766
     current:
@@ -146,11 +165,13 @@ button:
   - platform: factory_reset
     name: "Restart with Factory Default Settings"
     id: Reset
-
+    entity_category: config
+    
   - platform: safe_mode
     name: "Safe Mode"
     internal: false
-
+    entity_category: config
+    
 switch:
   - platform: gpio
     name: "${friendly_name}"
@@ -172,11 +193,60 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      entity_category: diagnostic
     ssid:
       name: "Connected SSID"
+      entity_category: diagnostic
     mac_address:
       name: "Mac Address"
+      entity_category: diagnostic
+
+  #  Creates a sensor showing when the device was last restarted
+  - platform: template
+    name: 'Device Last Restart'
+    id: device_last_restart
+    icon: mdi:clock
+    entity_category: diagnostic
+#    device_class: timestamp
+
+  #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
+  - platform: template
+    name: "Device Uptime"
+    entity_category: diagnostic
+    lambda: |-
+      int seconds = (id(uptime_sensor).state);
+      int days = seconds / (24 * 3600);
+      seconds = seconds % (24 * 3600);
+      int hours = seconds / 3600;
+      seconds = seconds % 3600;
+      int minutes = seconds /  60;
+      seconds = seconds % 60;
+      if ( days > 3650 ) {
+        return { "Starting up" };
+      } else if ( days ) {
+        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else if ( hours ) {
+        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else if ( minutes ) {
+        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else {
+        return { (String(seconds) +"s").c_str() };
+      }
+    icon: mdi:clock-start
 
 time:
   - platform: sntp
     id: sntp_time
+  # Change sync interval from default 5min to 6 hours
+    update_interval: 360min    
+  # Publish the time the device was last restarted
+    on_time_sync:
+      then:
+        # Update last restart time, but only once.
+        - if:
+            condition:
+              lambda: 'return id(device_last_restart).state == "";'
+            then:
+              - text_sensor.template.publish:
+                  id: device_last_restart
+                  state: !lambda 'return id(sntp_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");'


### PR DESCRIPTION
Changes: 

entity_category: diagnostic and entity_category: config - In HA this places these sensors and configuration items in the correct location, when viewing the individual devices in the ESP Home integration

Uptime Sensor & WiFi Signal - Change to internal, whilst allowing their use in sensors that format the output to be more useful or meaningful

WiFi Strength - Add sensor that reports signal as a %, as compared to Db that is meaningless to most people. Pulls data from WiFi Signal sensor.

Device Uptime - Add a sensor that uses Uptime Sensor to provide a formatted output of the days/hours/seconds the device has been up, as opposed to a xxxxxx seconds, that to be meaningful needs deciding with a calculator

sntp_time - Add a sensor that reports the actual date and time of when the device was last restarted