### PR TITLE
Fix athom-wall-outlet.yaml to address CSE7766 breaking change in ESPhome 2024.2

### DIFF
--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -4,6 +4,7 @@ substitutions:
   project_name: "Athom Technology.Wall Outlet"
   project_version: "1.1"
   relay_restore_mode: RESTORE_DEFAULT_OFF
+  sensor_update_interval: 10s
 
 esphome:
   name: "${device_name}"
@@ -90,12 +91,12 @@ sensor:
     voltage:
       name: "Voltage"
       filters:
-        - throttle_average: 10s
+        - throttle_average: ${sensor_update_interval}
     power:
       name: "Power"
       id: power_sensor
       filters:
-        - throttle_average: 10s
+        - throttle_average: ${sensor_update_interval}
       #  - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
 
 
@@ -106,7 +107,7 @@ sensor:
       filters:
         # Multiplication factor from W to kW is 0.001
         - multiply: 0.001
-        - throttle_average: 10s
+        - throttle_average: ${sensor_update_interval}
       on_value:
         then:
           - lambda: |-
@@ -124,7 +125,7 @@ sensor:
     accuracy_decimals: 3
     lambda: |-
       return id(total_energy);
-    update_interval: 10s
+    update_interval: ${sensor_update_interval}
 
   - platform: total_daily_energy
     name: "Total Daily Energy"

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -82,7 +82,6 @@ sensor:
     update_interval: 60s
 
   - platform: cse7766
-    update_interval: 10s
     current:
       name: "Current"
       # filters:
@@ -90,11 +89,14 @@ sensor:
 
     voltage:
       name: "Voltage"
+      filters:
+        - throttle_average: 10s
     power:
       name: "Power"
       id: power_sensor
-      # filters:
-      #     - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
+      filters:
+        - throttle_average: 10s
+      #  - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
 
 
     energy:
@@ -104,6 +106,7 @@ sensor:
       filters:
         # Multiplication factor from W to kW is 0.001
         - multiply: 0.001
+        - throttle_average: 10s
       on_value:
         then:
           - lambda: |-


### PR DESCRIPTION
In line to #39 this PR updates the Wall Outlet configuration to be compatible with ESPhome 2024.2

- removes `update_interval` from CSE7766 sensor configuration as it was removed in ESPhome 2024.2
- adds `throttle_average` to the relevant CSE7766 sensors 
- adds `sensor_update_interval` substitution for easy configuration 