### PR TITLE
Update athom-smart-plug-v2.yaml

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -1,16 +1,24 @@
 substitutions:
   name: "athom-smart-plug-v2"
   friendly_name: "Smart Plug V2"
+  # Allows ESP device to be automatically lined to an 'Area' in Home Assistant. Typically used for areas such as 'Lounge Room', 'Kitchen' etc
   room: ""
   device_description: "athom smart plug v2"
   project_name: "Athom Technology.Smart Plug V2"
   project_version: "2.0"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
+  # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
+  set_dns_domain: ""
+  # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
+  set_timezone: ""
+  # Enables faster network connections, with last connected SSID being connected to and no full scan for SSID being undertaken
+  wifi_fast_connect: "false" 
   
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
+  area: "${room}"
   name_add_mac_suffix: true
   project:
     name: "${project_name}"
@@ -38,6 +46,8 @@ web_server:
 
 wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
+  fast_connect: "${wifi_fast_connect}"
+  domain: "${set_dns_domain}"
 
 captive_portal:
 
@@ -236,6 +246,8 @@ text_sensor:
 time:
   - platform: sntp
     id: sntp_time
+  # Define the timezone of the device
+    timezone: "${set_timezone}"
   # Change sync interval from default 5min to 6 hours
     update_interval: 360min    
   # Publish the time the device was last restarted


### PR DESCRIPTION
Add:
1) Ability to define a timezone when sync'ing with SNTP. Normally plug will sync with timezone of the HA server, however this (optionally) allows defining a timezone for the plug in the substituions section.

2) Add support (optionally) being able to enable 'fast_connect' for the WiFi conenction. When the plug has previously connected to an SSID this allows the device to rapidly reconnect to it in future, without the delay caused by a full scan of the available SSID's in the area.

3) Add support (optional) for setting a dns_domain with the network connection. Defined in substitutions, instead of the plug obtaining a DHCP lease in your network and registering in the main dns zone, this allows allocating the plug to the correct network name / device purpose. i.e. In your 'home.lan' network if you have all IoT devices segemented off for security, you could use this to have the device register as 'smart-plug-v2.iot.home.lan'

4) Noticed the subsitutions has 'room:' as an entity, however it is not used. Added 'areas:' that calls the 'room' variable. This is in line with ESPHome adding the ability to inform the HomeAssistant (HA) server which 'area' with HA it should be allocated. This is instead of manually having to select this when (re)adding devices to HA.

BTW could the Repository owner please look to add the 'Discussions' feature to the Repo? ATM there is no way to communicate about possible changes, features to add or issue fixes. This means the only way to do any of this is to Request a Pull.