### PR TITLE
Update athom-smart-plug-v2.yaml

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -7,11 +7,13 @@ substitutions:
   project_version: "2.0"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
-  
+  current_limit : 16 # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
+  min_version: 2024.2.1
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -68,12 +70,12 @@ binary_sensor:
     disabled_by_default: true
     on_multi_click:
       - timing:
-          - ON for at most 1s
-          - OFF for at least 0.2s
+        - ON for at most 1s
+        - OFF for at least 0.2s
         then:
           - switch.toggle: relay
       - timing:
-          - ON for at least 4s
+        - ON for at least 4s
         then:
           - button.press: Reset
 
@@ -89,48 +91,38 @@ sensor:
     id: wifi_signal_db
     update_interval: 60s
     entity_category: diagnostic
-    internal: true
-
-  # Reports the WiFi signal strength in %
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Strength"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "%"
-    entity_category: diagnostic
-
 
   - platform: cse7766
     current:
       name: "Current"
       filters:
-          - throttle_average: ${sensor_update_interval}
-          - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
-
+        - throttle_average: ${sensor_update_interval}
+        - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
+      on_value_range:
+        - above: ${current_limit}
+          then:
+            - switch.turn_off: relay
 
     voltage:
       name: "Voltage"
       filters:
-          - throttle_average: ${sensor_update_interval}
+        - throttle_average: ${sensor_update_interval}
 
     power:
       name: "Power"
       id: power_sensor
       filters:
-          - throttle_average: ${sensor_update_interval}
-          - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
-
+        - throttle_average: ${sensor_update_interval}
+        - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
 
     energy:
       name: "Energy"
       id: energy
       unit_of_measurement: kWh
       filters:
-        - throttle_average: ${sensor_update_interval}
+        - throttle: ${sensor_update_interval}
         # Multiplication factor from W to kW is 0.001
         - multiply: 0.001
-        - filter_out: nan
       on_value:
         then:
           - lambda: |-
@@ -138,9 +130,11 @@ sensor:
               float current_energy_value = id(energy).state;
               id(total_energy) += current_energy_value - previous_energy_value;
               previous_energy_value = current_energy_value;
+              id(total_energy_sensor).update();
 
   - platform: template
     name: "Total Energy"
+    id: total_energy_sensor
     unit_of_measurement: kWh
     device_class: "energy"
     state_class: "total_increasing"
@@ -148,7 +142,7 @@ sensor:
     accuracy_decimals: 3
     lambda: |-
       return id(total_energy);
-    update_interval: ${sensor_update_interval}
+    update_interval: never
 
   - platform: total_daily_energy
     name: "Total Daily Energy"
@@ -159,22 +153,24 @@ sensor:
     filters:
       - multiply: 0.001
 
-
 button:
+  - platform: restart
+    name: "Restart"
+    entity_category: config
+
   - platform: factory_reset
-    name: "Restart with Factory Default Settings"
+    name: "Factory Reset"
     id: Reset
     entity_category: config
-    
+
   - platform: safe_mode
     name: "Safe Mode"
     internal: false
     entity_category: config
-    
+
 switch:
   - platform: gpio
-    name: "${friendly_name}"
-
+    name: "Switch"
     pin: GPIO12
     id: relay
     restore_mode: ${relay_restore_mode}
@@ -202,7 +198,7 @@ text_sensor:
 
   #  Creates a sensor showing when the device was last restarted
   - platform: template
-    name: 'Device Last Restart'
+    name: 'Last Restart'
     id: device_last_restart
     icon: mdi:clock
     entity_category: diagnostic
@@ -210,7 +206,7 @@ text_sensor:
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: template
-    name: "Device Uptime"
+    name: "Uptime"
     entity_category: diagnostic
     lambda: |-
       int seconds = (id(uptime_sensor).state);


### PR DESCRIPTION
- Remove 'nan' workaround from "Current" sensor, fixed in Esphome 2024.2.1
- Add "min_version" required for fix
- Add "Current" limiter to switch off relay when over maximum set current
- Fix "Current" sensor throttle to match example in Esphome docs
- Update "Total Energy" sensor only when there is new data
- Add "Restart" button
- Reverted "WiFi Strength" %, Home Assistant only accepts dB or dBm
- Change "Switch" name to 'Switch', otherwise it's friendly name is duplicated
- Shorten sensor names to fit Home Assistant dashboard
- Clean up extra whitespace