### PR TITLE
feat: lower threshold for current and power readings

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -120,7 +120,8 @@ sensor:
       name: "Current"
       filters:
         - throttle_average: ${sensor_update_interval}
-        - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
+      # - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
+        - lambda: if (x < 0.01) return 0.0; else return x;      # These values seem to work better, however the actual readings are off
       on_value_range:
         - above: ${current_limit}
           then:
@@ -136,7 +137,8 @@ sensor:
       id: power_sensor
       filters:
         - throttle_average: ${sensor_update_interval}
-        - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
+        # - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
+        - lambda: if (x < 0.3) return 0.0; else return x;       # These values seem to work better, however the actual readings are off
 
     energy:
       name: "Energy"


### PR DESCRIPTION
lowers the threshold for current and power readings to be reported the previous ones too often read as zero when using lower powere devices.
NB: it seems the readings are quite far off from the actual usage of the device when tested.