### PR TITLE
Add hide_switch option

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -8,6 +8,7 @@ substitutions:
   project_version: "v2.0.7"
   sensor_update_interval: "10s"
   relay_restore_mode: RESTORE_DEFAULT_ON
+  hide_switch: "false"
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
   current_limit : "16"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
@@ -334,6 +335,7 @@ switch:
     id: relay
     restore_mode: ${relay_restore_mode}
     icon: mdi:${power_plug_type}
+    internal: "${hide_switch}"
 
 light:
   - platform: status_led

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -9,6 +9,7 @@ substitutions:
   project_version: "v1.0.3"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
+  hide_switch: "false"
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
   current_limit : "10"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
@@ -345,6 +346,7 @@ switch:
     id: relay
     restore_mode: ${relay_restore_mode}
     icon: mdi:${power_plug_type}
+    internal: "${hide_switch}"
     on_turn_on:
       - light.turn_on: blue_led
 


### PR DESCRIPTION
Add an option to hide the switch from HA using the `internal` property.

Default is "false" to keep behavior the same as before.