### PR TITLE
Fix OTA for ESPHome 2024.6

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -1,13 +1,14 @@
 substitutions:
   device_name: "athom-cb02-switch"
   project_name: "Athom Technology.Switch Module"
-  project_version: "1.1"
+  project_version: "1.1.1"
   relay_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -22,6 +23,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -1,13 +1,13 @@
 substitutions:
   device_name: "athom-garage-door"
   project_name: "Athom Technology.Garage Door Opener"
-  project_version: "1.2"
-
+  project_version: "1.2.1"
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -18,9 +18,9 @@ esp8266:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
-
 
 mdns:
   disabled: false

--- a/athom-ls-4p-3wire.yaml
+++ b/athom-ls-4p-3wire.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-ls-4p-3wire"
   project_name: "Athom Technology.LS 4P 3Wire"
-  project_version: "1.1"
+  project_version: "1.1.1"
   button_toggle: "true"
   led_restore_mode: RESTORE_DEFAULT_OFF
   number_of_leds: '150'
@@ -12,6 +12,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -25,6 +26,7 @@ esp8266:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-ls-4p-4wire.yaml
+++ b/athom-ls-4p-4wire.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-ls-4p-4wire"
   project_name: "Athom Technology.LS 4P 4Wire"
-  project_version: "1.1"
+  project_version: "1.1.1"
   button_toggle: "true"
   light_restore_mode: RESTORE_DEFAULT_OFF
   number_of_leds: '150'
@@ -12,6 +12,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -25,6 +26,7 @@ esp8266:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -1,13 +1,14 @@
 substitutions:
   device_name: "athom-mini-switch"
   project_name: "Athom Technology.Mini Relay Switch Module"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -22,9 +23,9 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
-
 
 mdns:
   disabled: false

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -4,12 +4,13 @@ substitutions:
   room: ""
   device_description: "mmwave radar human presence sensor"
   project_name: "Athom Technology.Presence Sensor"
-  project_version: "1.0"
+  project_version: "1.0.1"
 
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -27,6 +28,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 mdns:
   disabled: false
@@ -66,7 +68,6 @@ uart:
   #     delimiter: "\n"
   #   sequence:
   #     - lambda: UARTDebug::log_string(direction, bytes);
-
 
 binary_sensor:
   - platform: status
@@ -116,7 +117,6 @@ binary_sensor:
       then:
         - light.turn_off: led
 
-
   - platform: template
     name: "Occupancy"
     id: occupancy
@@ -158,8 +158,6 @@ switch:
     turn_off_action:
       - uart.write: "sensorStop\r\n"
 
-
-
 number:
   - platform: template
     name: Farthest Detection          #Value range: 1.9 ~ 12m  Default: 6
@@ -183,7 +181,6 @@ number:
       - uart.write: "saveConfig\r\n"
       - delay: 500ms
       - switch.turn_on: mmwave_sensor
-
 
   - platform: template
     name: Maintain Sensitivity                 #Value range: 0 ~ 9   Default Maintain sensitivity: 7    Default Trigger sensitivity: 5
@@ -230,7 +227,6 @@ number:
       - delay: 500ms
       - switch.turn_on: mmwave_sensor
 
-
   - platform: template
     name: Detection Delay      #Confirmation delay      Value range: 0 ～ 100  default 0.050 seconds.
     id: Detection_Delay
@@ -276,7 +272,6 @@ number:
       - uart.write: "saveConfig\r\n"
       - delay: 500ms
       - switch.turn_on: mmwave_sensor
-
 
   - platform: template
     name: Blockade Time                  #Configure block time        Value range: 1 ～ 255, default 1 seconds.
@@ -352,4 +347,3 @@ text_sensor:
 time:
   - platform: sntp
     id: my_time
-

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -1,13 +1,14 @@
 substitutions:
   device_name: "athom-relay-board-x1"
   project_name: "Athom Technology.Relay-Board-X1"
-  project_version: "1.0"
+  project_version: "1.0.1"
   relay_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -22,6 +23,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-relay-board-x2"
   project_name: "Athom Technology.Relay-Board-X2"
-  project_version: "1.0"
+  project_version: "1.0.1"
   relay1_restore_mode: RESTORE_DEFAULT_OFF
   relay2_restore_mode: RESTORE_DEFAULT_OFF
 
@@ -9,6 +9,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -21,6 +22,7 @@ preferences:
   flash_write_interval: 1min
 
 api:
+  - platform: esphome
 
 ota:
 

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-relay-board-x4"
   project_name: "Athom Technology.Relay-Board-X4"
-  project_version: "1.0"
+  project_version: "1.0.1"
   relay1_restore_mode: RESTORE_DEFAULT_OFF
   relay2_restore_mode: RESTORE_DEFAULT_OFF
   relay3_restore_mode: RESTORE_DEFAULT_OFF
@@ -11,6 +11,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -25,6 +26,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 
@@ -105,4 +107,3 @@ text_sensor:
 time:
   - platform: sntp
     id: sntp_time
-

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-relay-board-x8"
   project_name: "Athom Technology.Relay-Board-X8"
-  project_version: "1.0"
+  project_version: "1.0.1"
   relay1_restore_mode: RESTORE_DEFAULT_OFF
   relay2_restore_mode: RESTORE_DEFAULT_OFF
   relay3_restore_mode: RESTORE_DEFAULT_OFF
@@ -15,6 +15,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -29,6 +30,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -1,13 +1,14 @@
 substitutions:
   device_name: "athom-rgb-light"
   project_name: "Athom Technology.RGB Light Strip Controller"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -22,6 +23,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0
@@ -78,7 +80,6 @@ button:
   - platform: safe_mode
     name: "Safe Mode"
     internal: false
-
 
 output:
   - platform: esp8266_pwm

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-rgbct-light"
   project_name: "Athom Technology.RGBCCT Bulb"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light_restore_mode: RESTORE_DEFAULT_ON
   color_interlock: 'true'
 
@@ -15,6 +15,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -32,6 +33,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -1,13 +1,14 @@
 substitutions:
   device_name: "athom-rgbw-light"
   project_name: "Athom Technology.RGBW Light Strip Controller"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -19,6 +20,7 @@ esp8266:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 
@@ -101,7 +103,6 @@ light:
     blue: output_blue
     white: output_white
     color_interlock: true
-
 
 text_sensor:
   - platform: wifi_info

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-rgbww-light"
   project_name: "Athom Technology.RGBCW Bulb"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light_restore_mode: RESTORE_DEFAULT_ON
   color_interlock: 'true'
 
@@ -15,6 +15,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -32,6 +33,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 
@@ -96,7 +98,6 @@ output:
     pin: GPIO5
     min_power: 0.000499
     max_power: 1
-
 
 light:
   - platform: rgbww

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -5,7 +5,7 @@ substitutions:
   room: ""
   device_description: "athom smart plug v2"
   project_name: "Athom Technology.Smart Plug V2"
-  project_version: "2.0.2"
+  project_version: "2.0.3"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
@@ -17,13 +17,12 @@ substitutions:
   # Enables faster network connections, with last connected SSID being connected to and no full scan for SSID being undertaken
   wifi_fast_connect: "false" 
   
-
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   area: "${room}"
   name_add_mac_suffix: true
-  min_version: 2024.2.1
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -35,10 +34,10 @@ esp8266:
 preferences:
   flash_write_interval: 5min
 
-
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -4,7 +4,7 @@ substitutions:
   room: ""
   device_description: "athom smart plug"
   project_name: "Athom Technology.Smart Plug"
-  project_version: "1.0"
+  project_version: "1.0.1"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
 
@@ -12,6 +12,7 @@ esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -26,6 +27,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
 
@@ -138,7 +140,6 @@ sensor:
     filters:
       - multiply: 0.001
 
-
 button:
   - platform: factory_reset
     name: "Reset"
@@ -232,4 +233,3 @@ time:
               - text_sensor.template.publish:
                   id: device_last_restart
                   state: !lambda 'return id(sntp_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");'
-

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -1,13 +1,14 @@
 substitutions:
   device_name: "athom-1gang-switch-v2"
   project_name: "Athom Technology.1 Gang Switch V2"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -22,6 +23,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -1,13 +1,14 @@
 substitutions:
   device_name: "athom-1gang-switch"
   project_name: "Athom Technology.1 Gang Switch"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light_restore_mode: RESTORE_DEFAULT_OFF
 
 esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -22,6 +23,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-2gang-switch-v2"
   project_name: "Athom Technology.2 Gang Switch V2"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
 
@@ -9,6 +9,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -23,6 +24,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-2gang-switch"
   project_name: "Athom Technology.2 Gang Switch"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
 
@@ -9,6 +9,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -23,6 +24,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-3gang-switch"
   project_name: "Athom Technology.3 Gang Switch"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
   light3_restore_mode: RESTORE_DEFAULT_OFF
@@ -10,6 +10,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -24,6 +25,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-4gang-switch"
   project_name: "Athom Technology.4 Gang Switch"
-  project_version: "1.1"
+  project_version: "1.1.1"
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
   light3_restore_mode: RESTORE_DEFAULT_OFF
@@ -11,6 +11,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -25,6 +26,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -2,7 +2,7 @@ substitutions:
   device_name: "athom-wall-outlet"
   # friendly_name: "Athom Wall Outlet"
   project_name: "Athom Technology.Wall Outlet"
-  project_version: "1.1"
+  project_version: "1.1.1"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
 
@@ -10,6 +10,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -24,6 +25,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0
@@ -135,7 +137,6 @@ sensor:
     accuracy_decimals: 3
     filters:
       - multiply: 0.001
-
 
 button:
   - platform: factory_reset

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -1,7 +1,7 @@
 substitutions:
   device_name: "athom-ws2812b"
   project_name: "Athom Technology.WS2812B Controller"
-  project_version: "1.1"
+  project_version: "1.1.1"
   button_toggle: "true"
   led_restore_mode: RESTORE_DEFAULT_OFF
   number_of_leds: '150'
@@ -12,6 +12,7 @@ esphome:
   name: "${device_name}"
   friendly_name: ""
   name_add_mac_suffix: true
+  min_version: 2024.6.0
   project:
     name: "${project_name}"
     version: "${project_version}"
@@ -28,6 +29,7 @@ preferences:
 api:
 
 ota:
+  - platform: esphome
 
 logger:
   baud_rate: 0
@@ -37,7 +39,6 @@ mdns:
 
 web_server:
   port: 80
-
 
 wifi:
   ap: {} # This spawns an AP with the device name and mac address with no password.
@@ -111,4 +112,3 @@ text_sensor:
 time:
   - platform: sntp
     id: sntp_time
-


### PR DESCRIPTION
- Changed all project versions to follow the three-part version numbering and incremented by 0.0.1
- Added ESPHome "min_version" to all and adjusted existing to "2024.6.0"
- Added ota "platform" to all (required from ESPHome 2024.6.0)
- Removed some extra empty lines to clean up