### PR TITLE
Roving ronin plug v1 to v2andv3 baseline

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -211,7 +211,7 @@ sensor:
 
      # Dentra Components - Define the id of the sensor providing 'Total Energy' used
   - platform: "energy_statistics"
-    total: energy_total_sensor
+    total: total_energy_sensor
 
      # Dentra Components - Adds Energy Yesterday
     energy_yesterday:

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -5,7 +5,7 @@ substitutions:
   room: ""
   device_description: "athom smart plug v2"
   project_name: "Athom Technology.Smart Plug V2"
-  project_version: "2.0.3"
+  project_version: "2.0.4"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
@@ -14,12 +14,25 @@ substitutions:
   dns_domain: ""
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
+  # Set the duration between the sntp service polling ntp.org servers for an update
+  sntp_update_interval: 6h
+  # Network time servers for your region, enter from lowest to highest priority. To use local servers update as per zones or countries at: https://www.ntppool.org/zone/@
+  sntp_server_1: "0.pool.ntp.org"
+  sntp_server_2: "1.pool.ntp.org"
+  sntp_server_3: "2.pool.ntp.org"  
   # Enables faster network connections, with last connected SSID being connected to and no full scan for SSID being undertaken
-  wifi_fast_connect: "false" 
-  
+  wifi_fast_connect: "false"
+  # Define logging level: NONE, ERROR, WARN, INFO, DEBUG (Default), VERBOSE, VERY_VERBOSE
+  log_level: "INFO"
+  # Hide the ENERGY sensor that shows kWh consumed, but with no time period associated with it. Resets when device restarted and reflashed.
+  hide_energy_sensor: true
+
+
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
+  comment: "${device_description}"
   area: "${room}"
   name_add_mac_suffix: true
   min_version: 2024.6.0
@@ -40,6 +53,7 @@ ota:
   - platform: esphome
 
 logger:
+  level: ${log_level}
   baud_rate: 0
 
 mdns:
@@ -49,14 +63,22 @@ web_server:
   port: 80
 
 wifi:
-  ap: {} # This spawns an AP with the device name and mac address with no password.
+  # This spawns an AP with the device name and mac address with no password.
+  ap: {}
+  # Allow rapid re-connection to previously connect WiFi SSID, skipping scan of all SSID
   fast_connect: "${wifi_fast_connect}"
+  # Define dns domain / suffix to add to hostname
   domain: "${dns_domain}"
 
 captive_portal:
 
 dashboard_import:
   package_import_url: github://athom-tech/athom-configs/athom-smart-plug-v2.yaml
+
+# Dentra Components - Adds 'Platform - Energy Statistics'
+# https://github.com/dentra/esphome-components/tree/master/components/energy_statistics
+external_components:
+  - source: github://dentra/esphome-components
 
 uart:
   rx_pin: RX
@@ -153,11 +175,13 @@ sensor:
               id(total_energy) += current_energy_value - previous_energy_value;
               previous_energy_value = current_energy_value;
               id(total_energy_sensor).update();
+      internal: ${hide_energy_sensor}
 
     apparent_power:
       name: "Apparent Power"
       filters:
         - throttle_average: ${sensor_update_interval}
+        
     power_factor:
       name: "Power Factor"
       filters:
@@ -173,16 +197,39 @@ sensor:
     accuracy_decimals: 3
     lambda: |-
       return id(total_energy);
-    update_interval: never
+    update_interval: ${sensor_update_interval}
 
-  - platform: total_daily_energy
-    name: "Total Daily Energy"
+  - platform: total_energy_today
+    name: "Total Energy Today"
     restore: true
     power_id: power_sensor
     unit_of_measurement: kWh
+    icon: mdi:hours-24
     accuracy_decimals: 3
     filters:
       - multiply: 0.001
+
+     # Dentra Components - Define the id of the sensor providing 'Total Energy' used
+  - platform: "energy_statistics"
+    total: energy_total_sensor
+
+     # Dentra Components - Adds Energy Yesterday
+    energy_yesterday:
+      name: "Total Energy Yesterday"
+      id: total_energy_yesterday
+      accuracy_decimals: 3
+
+     # Dentra Components - Adds Energy Week
+    energy_week:
+      name: "Total Energy Week"
+      id: total_energy_week
+      accuracy_decimals: 3
+
+     # Dentra Components - Adds Energy Month
+    energy_month:
+      name: "Total Energy Month"
+      id: total_energy_month
+      accuracy_decimals: 3
 
 button:
   - platform: restart
@@ -265,8 +312,13 @@ time:
     id: sntp_time
   # Define the timezone of the device
     timezone: "${timezone}"
-  # Change sync interval from default 5min to 6 hours
-    update_interval: 360min    
+  # Change sync interval from default 5min to 6 hours (or as set in substitutions)
+    update_interval: ${sntp_update_interval}
+  # Set specific sntp servers to use
+    servers: 
+      - "${sntp_server_1}"
+      - "${sntp_server_2}"
+      - "${sntp_server_3}"    
   # Publish the time the device was last restarted
     on_time_sync:
       then:

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -199,7 +199,7 @@ sensor:
       return id(total_energy);
     update_interval: ${sensor_update_interval}
 
-  - platform: total_energy_today
+  - platform: total_daily_energy
     name: "Total Energy Today"
     restore: true
     power_id: power_sensor

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -200,7 +200,7 @@ sensor:
     update_interval: ${sensor_update_interval}
 
 #  - platform: total_daily_energy
-#    name: "Total Energy Today"
+#    name: "Total Energy Since Boot
 #    restore: true
 #    power_id: power_sensor
 #    unit_of_measurement: kWh

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -199,19 +199,26 @@ sensor:
       return id(total_energy);
     update_interval: ${sensor_update_interval}
 
-  - platform: total_daily_energy
-    name: "Total Energy Today"
-    restore: true
-    power_id: power_sensor
-    unit_of_measurement: kWh
-    icon: mdi:hours-24
-    accuracy_decimals: 3
-    filters:
-      - multiply: 0.001
+#  - platform: total_daily_energy
+#    name: "Total Energy Today"
+#    restore: true
+#    power_id: power_sensor
+#    unit_of_measurement: kWh
+#    icon: mdi:hours-24
+#    accuracy_decimals: 3
+#    filters:
+#      - multiply: 0.001
 
      # Dentra Components - Define the id of the sensor providing 'Total Energy' used
   - platform: "energy_statistics"
     total: total_energy_sensor
+
+     # Dentra Components - Adds Energy Today. Persistents if restarted, unlike 'total_daily_energy'
+    energy_today:
+      name: "Energy Today"
+      id: total_energy_today
+      accuracy_decimals: 3
+      icon: mdi:hours-24
 
      # Dentra Components - Adds Energy Yesterday
     energy_yesterday:

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -6,8 +6,8 @@ substitutions:
   device_description: "athom smart plug v2"
   project_name: "Athom Technology.Smart Plug V2"
   project_version: "2.0.4"
-  relay_restore_mode: RESTORE_DEFAULT_OFF
-  sensor_update_interval: 10s
+  relay_restore_mode: "RESTORE_DEFAULT_OFF"
+  sensor_update_interval: "10s"
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
   current_limit : "16"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
@@ -15,7 +15,7 @@ substitutions:
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update
-  sntp_update_interval: 6h
+  sntp_update_interval: "6h"
   # Network time servers for your region, enter from lowest to highest priority. To use local servers update as per zones or countries at: https://www.ntppool.org/zone/@
   sntp_server_1: "0.pool.ntp.org"
   sntp_server_2: "1.pool.ntp.org"
@@ -25,7 +25,7 @@ substitutions:
   # Define logging level: NONE, ERROR, WARN, INFO, DEBUG (Default), VERBOSE, VERY_VERBOSE
   log_level: "INFO"
   # Hide the ENERGY sensor that shows kWh consumed, but with no time period associated with it. Resets when device restarted and reflashed.
-  hide_energy_sensor: true
+  hide_energy_sensor: "true"
 
 
 

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -200,7 +200,7 @@ sensor:
     update_interval: ${sensor_update_interval}
 
 #  - platform: total_daily_energy
-#    name: "Total Energy Since Boot
+#    name: "Total Energy Since Boot"
 #    restore: true
 #    power_id: power_sensor
 #    unit_of_measurement: kWh

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -1,16 +1,38 @@
 substitutions:
+
   name: "athom-smart-plug"
   friendly_name: "Smart Plug"
+  # Allows ESP device to be automatically lined to an 'Area' in Home Assistant. Typically used for areas such as 'Lounge Room', 'Kitchen' etc
   room: ""
   device_description: "athom smart plug"
   project_name: "Athom Technology.Smart Plug"
-  project_version: "1.0.1"
+  project_version: "1.0.2"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
+  # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
+  current_limit : "10"
+  # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
+  dns_domain: ""
+  # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
+  timezone: ""
+  # Set the duration between the sntp service polling ntp.org servers for an update
+  sntp_update_interval: "6h"
+  # Network time servers for your region, enter from lowest to highest priority. To use local servers update as per zones or countries at: https://www.ntppool.org/zone/@
+  sntp_server_1: "0.pool.ntp.org"
+  sntp_server_2: "1.pool.ntp.org"
+  sntp_server_3: "2.pool.ntp.org"  
+  # Enables faster network connections, with last connected SSID being connected to and no full scan for SSID being undertaken
+  wifi_fast_connect: "false"
+  # Define logging level: NONE, ERROR, WARN, INFO, DEBUG (Default), VERBOSE, VERY_VERBOSE
+  log_level: "INFO"
+  # Hide the ENERGY sensor that shows kWh consumed, but with no time period associated with it. Resets when device restarted and reflashed.
+  hide_energy_sensor: "true"  
 
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
+  comment: "${device_description}"
+  area: "${room}"
   name_add_mac_suffix: true
   min_version: 2024.6.0
   project:
@@ -22,7 +44,7 @@ esp8266:
   restore_from_flash: true
 
 preferences:
-  flash_write_interval: 1min
+  flash_write_interval: 5min
 
 api:
 
@@ -30,17 +52,43 @@ ota:
   - platform: esphome
 
 logger:
+  level: ${log_level}
+  baud_rate: 0
+
+mdns:
+  disabled: false
 
 web_server:
   port: 80
 
 wifi:
-  ap: {} # This spawns an AP with the device name and mac address with no password.
+  # This spawns an AP with the device name and mac address with no password.
+  ap: {}
+  # Allow rapid re-connection to previously connect WiFi SSID, skipping scan of all SSID
+  fast_connect: "${wifi_fast_connect}"
+  # Define dns domain / suffix to add to hostname
+  domain: "${dns_domain}"
 
 captive_portal:
 
 dashboard_import:
   package_import_url: github://athom-tech/athom-configs/athom-smart-plug.yaml
+
+# Dentra Components - Adds 'Platform - Energy Statistics'
+# https://github.com/dentra/esphome-components/tree/master/components/energy_statistics
+external_components:
+  - source: github://dentra/esphome-components
+
+globals:
+  - id: total_energy
+    type: float
+    restore_value: yes
+    initial_value: '0.0' 
+
+  - id: restore_mode
+    type: int
+    restore_value: yes
+    initial_value: "3"
 
 binary_sensor:
   - platform: status
@@ -95,8 +143,12 @@ sensor:
     cf_pin: GPIO4
     cf1_pin: GPIO5
     voltage_divider: 780
+
     current:
       name: "Current"
+      id: current
+      unit_of_measurement: A
+      accuracy_decimals: 2
       filters:
           - calibrate_linear:
             - 0.0000 -> 0.0110 # Relay off no load
@@ -109,13 +161,24 @@ sensor:
             - 9.9171 -> 7.9830
           # Normalize for plug load
           - lambda: if (x < 0.0260) return 0; else return (x - 0.0260);
+      on_value_range:
+        - above: ${current_limit}
+          then:
+            - switch.turn_off: relay      
+
     voltage:
       name: "Voltage"
+      id:   voltage
+      unit_of_measurement: V
+      accuracy_decimals: 1
+      filters:
+        - skip_initial: 2
 
     power:
       name: "Power"
       id: socket_my_power
       unit_of_measurement: W
+      accuracy_decimals: 1
       filters:
           - calibrate_linear:
             - 0.0000 -> 0.5900 # Relay off no load
@@ -131,8 +194,40 @@ sensor:
     change_mode_every: 1
     update_interval: 5s
 
-  - platform: total_daily_energy
+    # Shows the Energy kWh since the device was last started
+    energy:
+      name: "Energy"
+      id: energy
+      unit_of_measurement: kWh
+      accuracy_decimals: 3
+      filters:
+         # Multiplication factor from W to kW is 0.001
+        - multiply: 0.001
+      on_value:
+        then:
+          - lambda: |-
+              static float previous_energy_value = 0.0;
+              float current_energy_value = id(energy).state;
+              id(total_energy) += current_energy_value - previous_energy_value;
+              previous_energy_value = current_energy_value;
+              id(energy_total_sensor).update();
+      internal: true
+
+    # Shows the TOTAL/Lifetime Energy kWh used by the device, may reset to zero upon firmware updates
+  - platform: template
     name: "Total Energy"
+    id: total_energy_sensor
+    unit_of_measurement: kWh
+    device_class: "energy"
+    state_class: "total_increasing"
+    icon: "mdi:lightning-bolt"
+    accuracy_decimals: 3
+    lambda: |-
+      return id(total_energy);
+    update_interval: ${sensor_update_interval}
+
+  - platform: total_daily_energy
+    name: "Total Energy Today"
     power_id: socket_my_power
     unit_of_measurement: kWh
     accuracy_decimals: 3
@@ -140,7 +235,33 @@ sensor:
     filters:
       - multiply: 0.001
 
+     # Dentra Components - Define the id of the sensor providing 'Total Energy' used
+  - platform: "energy_statistics"
+    total: total_energy_sensor
+
+     # Dentra Components - Adds Energy Yesterday
+    energy_yesterday:
+      name: "Total Energy Yesterday"
+      id: total_energy_yesterday
+      accuracy_decimals: 3
+
+     # Dentra Components - Adds Energy Week
+    energy_week:
+      name: "Total Energy Week"
+      id: total_energy_week
+      accuracy_decimals: 3
+
+     # Dentra Components - Adds Energy Month
+    energy_month:
+      name: "Total Energy Month"
+      id: total_energy_month
+      accuracy_decimals: 3
+
 button:
+  - platform: restart
+    name: "Restart"
+    entity_category: config
+
   - platform: factory_reset
     name: "Reset"
     id: Reset
@@ -186,7 +307,7 @@ text_sensor:
 
   #  Creates a sensor showing when the device was last restarted
   - platform: template
-    name: 'Device Last Restart'
+    name: 'Last Restart'
     id: device_last_restart
     icon: mdi:clock
     entity_category: diagnostic
@@ -194,7 +315,7 @@ text_sensor:
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: template
-    name: "Device Uptime"
+    name: "Uptime"
     entity_category: diagnostic
     lambda: |-
       int seconds = (id(uptime_sensor).state);
@@ -220,8 +341,15 @@ text_sensor:
 time:
   - platform: sntp
     id: sntp_time
-  # Change sync interval from default 5min to 6 hours
-    update_interval: 360min    
+  # Define the timezone of the device
+    timezone: "${timezone}"
+  # Change sync interval from default 5min to 6 hours (or as set in substitutions)
+    update_interval: ${sntp_update_interval}
+  # Set specific sntp servers to use
+    servers: 
+      - "${sntp_server_1}"
+      - "${sntp_server_2}"
+      - "${sntp_server_3}"    
   # Publish the time the device was last restarted
     on_time_sync:
       then:

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -226,18 +226,26 @@ sensor:
       return id(total_energy);
     update_interval: ${sensor_update_interval}
 
-  - platform: total_daily_energy
-    name: "Total Energy Today"
-    power_id: socket_my_power
-    unit_of_measurement: kWh
-    accuracy_decimals: 3
-    restore: true
-    filters:
-      - multiply: 0.001
+#  - platform: total_daily_energy
+#    name: "Total Energy Since Boot"
+#    power_id: socket_my_power
+#    unit_of_measurement: kWh
+#    accuracy_decimals: 3
+#    restore: true
+#    filters:
+#      - multiply: 0.001
+#    internal: true
 
      # Dentra Components - Define the id of the sensor providing 'Total Energy' used
   - platform: "energy_statistics"
     total: total_energy_sensor
+
+     # Dentra Components - Adds Energy Today. Persistents if restarted, unlike 'total_daily_energy'
+    energy_today:
+      name: "Total Energy Today"
+      id: total_energy_today
+      accuracy_decimals: 3
+      icon: mdi:hours-24
 
      # Dentra Components - Adds Energy Yesterday
     energy_yesterday:


### PR DESCRIPTION
Replace 'Total Energy Today' with Dentra Component that provides this information, but is persistent between reboots / reflashing versus the previous version that reset to zero every time.