### PR TITLE
on_boot default and icon

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -120,13 +120,14 @@ globals:
   - id: restore_mode
     type: int
     restore_value: yes
-    initial_value: "3"
+    initial_value: "2"      # 0 = Always_Off. 1 = Restore_Power_Off. 2 = Always_On.
 
 select:
   - platform: template
     name: "Power On State"
     id: "power_mode"
     optimistic: true
+    icon: "mdi:electric-switch"
     options:
       - Always Off
       - Always On


### PR DESCRIPTION
-  Change on_boot restore default value to 2 (Always_On). This is best set to ON and not OFF, to avoid devices being turned off when users first update. If they want it OFF, then it can be updated post flashing.

-  Add icon for the Selector.

