### PR TITLE
Update athom-garage-door.yaml

### DIFF
--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -42,7 +42,7 @@ esphome:
     version: "${project_version}"
 
 esp8266:
-  board: esp8285
+  board: esp01_1m
 
 api:
 


### PR DESCRIPTION
Newly manufactured openers seem to use a different ESP8266 board type