### PR TITLE
Add parity for UART

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -111,6 +111,7 @@ dashboard_import:
 uart:
   rx_pin: RX
   baud_rate: 4800
+  parity: EVEN
 
 globals:
   - id: total_energy


### PR DESCRIPTION
Add parity for CSE7766 as required after breaking change in ESPHome 2024.10 ( https://esphome.io/changelog/2024.10.0.html )