### PR TITLE
Smart Plug v2 - Add MDI icons to sensors missing them

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -5,7 +5,7 @@ substitutions:
   room: ""
   device_description: "athom smart plug v2"
   project_name: "Athom Technology.Smart Plug V2"
-  project_version: "v2.0.6"
+  project_version: "v2.0.7"
   sensor_update_interval: "10s"
   relay_restore_mode: RESTORE_DEFAULT_ON
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
@@ -30,6 +30,11 @@ substitutions:
   hide_energy_sensor: "false"
   # Specifies whether pins should be initialised as early as possible to known values. Recommended value is false where switches are involved, as these will toggle when updating the firmware or when restarting the device. Defaults to true.
   early_pin_init: "true"
+  # Power plug icon selection. Change to reflect the type/country of powr plug in use, this will update the power plug icon shown next to the switch
+  power_plug_type: "power-socket-us"  # Options: power-socket-au | power-socket-ch | power-socket-de | power-socket-eu | power-socket-fr | power-socket-it | power-socket-jp | power-socket-uk | power-socket-us |
+
+
+########################## End of Substitutions #########################
 
 esphome:
   name: "${name}"
@@ -86,6 +91,7 @@ mdns:
 
 web_server:
   port: 80
+#  version: 3
 
 network:
   enable_ipv6: ${ipv6_enable}
@@ -128,7 +134,7 @@ select:
     name: "Power On State"
     id: "power_mode"
     optimistic: true
-    icon: "mdi:electric-switch"
+    icon: mdi:electric-switch
     options:
       - Always Off
       - Always On
@@ -141,6 +147,7 @@ select:
 binary_sensor:
   - platform: status
     name: "Status"
+    icon: mdi:check-network-outline
     entity_category: diagnostic    
 
   - platform: gpio
@@ -189,6 +196,7 @@ sensor:
   - platform: cse7766
     current:
       name: "Current"
+      icon: mdi:current-ac
       filters:
         - throttle_average: ${sensor_update_interval}
         - lambda: if (x < 0.060) return 0.0; else return x;   #For the chip will report less than 3w power when no load is connected
@@ -199,12 +207,14 @@ sensor:
 
     voltage:
       name: "Voltage"
+      icon: mdi:sine-wave
       filters:
         - throttle_average: ${sensor_update_interval}
 
     power:
       name: "Power"
       id: power_sensor
+      icon: mdi:power
       filters:
         - throttle_average: ${sensor_update_interval}
         - lambda: if (x < 3.0) return 0.0; else return x;    #For the chip will report less than 3w power when no load is connected
@@ -212,6 +222,7 @@ sensor:
     energy:
       name: "Energy"
       id: energy
+      icon: mdi:lightning-bolt
       unit_of_measurement: kWh
       internal: ${hide_energy_sensor}
       filters:
@@ -230,14 +241,19 @@ sensor:
 
     apparent_power:
       name: "Apparent Power"
+      icon: mdi:power
       filters:
         - throttle_average: ${sensor_update_interval}
+
     reactive_power:
       name: "Reactive Power"
+      icon: mdi:flash
       filters:
         - throttle_average: ${sensor_update_interval}
+
     power_factor:
       name: "Power Factor"
+      icon: mdi:percent-outline
       filters:
         - throttle_average: ${sensor_update_interval}
 
@@ -247,7 +263,7 @@ sensor:
     unit_of_measurement: kWh
     device_class: "energy"
     state_class: "total_increasing"
-    icon: "mdi:lightning-bolt"
+    icon: mdi:lightning-bolt
     accuracy_decimals: 3
     lambda: |-
       return id(total_energy);
@@ -278,12 +294,14 @@ sensor:
   #   energy_yesterday:
   #     name: "Total Energy Yesterday"
   #     id: total_energy_yesterday
+  #     icon: mdi:calendar-today
   #     accuracy_decimals: 3
 
   #    # Dentra Components - Adds Energy Week
   #   energy_week:
   #     name: "Total Energy Week"
   #     id: total_energy_week
+  #     icon: mdi:calendar-week
   #     accuracy_decimals: 3
 
   #    # Dentra Components - Adds Energy Month
@@ -291,6 +309,7 @@ sensor:
   #     name: "Total Energy Month"
   #     id: total_energy_month
   #     accuracy_decimals: 3
+  #     icon: mdi:calendar-month
 
 button:
   - platform: restart
@@ -313,11 +332,13 @@ switch:
     pin: GPIO12
     id: relay
     restore_mode: ${relay_restore_mode}
+    icon: mdi:${power_plug_type}
 
 light:
   - platform: status_led
     name: "Status LED"
     id: blue_led
+    icon: mdi:lightbulb-outline
     disabled_by_default: true
     pin:
       inverted: true
@@ -327,12 +348,15 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      icon: mdi:ip-network
       entity_category: diagnostic
     ssid:
       name: "Connected SSID"
+      icon: mdi:wifi-strength-2
       entity_category: diagnostic
     mac_address:
       name: "Mac Address"
+      icon: mdi:network-pos
       entity_category: diagnostic
 
   #  Creates a sensor showing when the device was last restarted


### PR DESCRIPTION
- Adds MDI icons to sensors that are missing them.
- For power plug icon, to allow people to update to reflect the type of plug their country uses, adds a substitute for this mdi icon, so they can update that and have their choosen icon/plug used.

