### PR TITLE
split wifi sensors into a separate file, uncontroversial example change

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -151,21 +154,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -202,17 +190,6 @@ light:
       number: GPIO4
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -81,21 +84,6 @@ sensor:
     id: uptime_sensor
     entity_category: diagnostic
     internal: true
-
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
 
 binary_sensor:
   - platform: status
@@ -189,17 +177,6 @@ cover:
             - switch.turn_on: relay
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-ls-4p-3wire.yaml
+++ b/athom-ls-4p-3wire.yaml
@@ -8,6 +8,9 @@ substitutions:
   led_rgb_order: GRB
   led_chipset: WS2811
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${device_name}"
   friendly_name: ""
@@ -71,10 +74,6 @@ sensor:
   - platform: uptime
     name: "Uptime Sensor"
 
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-
 button:
   - platform: factory_reset
     name: "Reset"
@@ -101,15 +100,6 @@ light:
     effects:
       - addressable_rainbow:
       - addressable_scan:
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-    ssid:
-      name: "Connected SSID"
-    mac_address:
-      name: "Mac Address"
 
 time:
   - platform: sntp

--- a/athom-ls-4p-4wire.yaml
+++ b/athom-ls-4p-4wire.yaml
@@ -8,6 +8,9 @@ substitutions:
   led_chipset: WS2801
   led_rgb_order: GRB
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${device_name}"
   friendly_name: ""
@@ -71,10 +74,6 @@ sensor:
   - platform: uptime
     name: "Uptime Sensor"
 
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-
 button:
   - platform: factory_reset
     name: "Reset"
@@ -102,15 +101,6 @@ light:
     effects:
       - addressable_rainbow:
       - addressable_scan:
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-    ssid:
-      name: "Connected SSID"
-    mac_address:
-      name: "Mac Address"
 
 time:
   - platform: sntp

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -167,21 +170,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 binary_sensor:
   # Wired switch
   - platform: gpio
@@ -230,17 +218,6 @@ binary_sensor:
     entity_category: diagnostic
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -28,6 +28,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -175,21 +178,6 @@ sensor:
     id: uptime_sensor
     entity_category: diagnostic
     internal: true
-
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
 
   - platform: bh1750
     name: "Light Sensor"
@@ -408,17 +396,6 @@ button:
       - button.press: restart_esp
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -88,21 +91,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -135,17 +123,6 @@ light:
       number: GPIO16
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -31,6 +31,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -89,21 +92,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -142,17 +130,6 @@ light:
       number: GPIO16
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -33,6 +33,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -91,21 +94,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -155,17 +143,6 @@ light:
       number: GPIO5
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -37,6 +37,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -94,21 +97,6 @@ sensor:
     id: uptime_sensor
     entity_category: diagnostic
     internal: true
-
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
 
 button:
   - platform: restart
@@ -183,17 +171,6 @@ light:
       number: GPIO2
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -109,21 +112,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -160,17 +148,6 @@ light:
     id: led
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -31,6 +31,9 @@ substitutions:
   ipv6_enable: "false"
   color_interlock: "true"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 globals:
   - id: fast_boot
     type: int
@@ -143,21 +146,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -221,17 +209,6 @@ light:
     color_interlock: ${color_interlock}
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -31,6 +31,9 @@ substitutions:
   ipv6_enable: "false"
   color_interlock: "true"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -105,21 +108,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -161,18 +149,6 @@ light:
     blue: output_blue
     white: output_white
     color_interlock: ${color_interlock}
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
 
   #  Creates a sensor showing when the device was last restarted
   - platform: template

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -31,6 +31,9 @@ substitutions:
   ipv6_enable: "false"
   color_interlock: "true"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 globals:
   - id: fast_boot
     type: int
@@ -141,21 +144,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -213,17 +201,6 @@ light:
     color_interlock: ${color_interlock}
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -31,6 +31,9 @@ substitutions:
   # Specifies whether pins should be initialised as early as possible to known values. Recommended value is false where switches are involved, as these will toggle when updating the firmware or when restarting the device. Defaults to true.
   early_pin_init: "true"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -168,23 +171,6 @@ sensor:
     id: uptime_sensor
     entity_category: diagnostic
     internal: true
-
-  # Reports the WiFi signal strength/RSSI in dB
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: diagnostic
-
-  # Reports the WiFi signal strength in %
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "%"
-    entity_category: diagnostic
-    device_class: ""
 
   - platform: cse7766
     current:
@@ -324,17 +310,6 @@ light:
       number: GPIO13
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Hide the ENERGY sensor that shows kWh consumed, but with no time period associated with it. Resets when device restarted and reflashed.
   hide_energy_sensor: "true"  
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -161,23 +164,6 @@ sensor:
     id: uptime_sensor
     entity_category: diagnostic
     internal: True
-
-  # Reports the WiFi signal strength/RSSI in dB
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: diagnostic
-
-  # Reports the WiFi signal strength in %
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "%"
-    entity_category: diagnostic
-    device_class: ""
 
   - platform: hlw8012
     sel_pin:
@@ -344,17 +330,6 @@ light:
       number: GPIO13
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -155,21 +158,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -225,17 +213,6 @@ light:
     default_transition_length: 500ms
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -30,6 +30,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -155,21 +158,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -225,17 +213,6 @@ light:
     default_transition_length: 500ms
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -31,6 +31,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -173,21 +176,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -271,17 +259,6 @@ light:
     default_transition_length: 500ms
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -31,6 +31,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -173,21 +176,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -266,17 +254,6 @@ light:
     default_transition_length: 500ms
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -32,6 +32,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -191,21 +194,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -307,17 +295,6 @@ light:
     default_transition_length: 500ms
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -33,6 +33,9 @@ substitutions:
   # Enable or disable the use of IPv6 networking on the device
   ipv6_enable: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -193,21 +196,6 @@ sensor:
     entity_category: diagnostic
     internal: true
 
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"
-    device_class: ""
-
 button:
   - platform: restart
     name: "Restart"
@@ -267,18 +255,6 @@ light:
     id: light4
     output: relay4
     restore_mode: ${light4_restore_mode}
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
 
   #  Creates a sensor showing when the device was last restarted
   - platform: template

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -29,6 +29,9 @@ substitutions:
   # Hide the ENERGY sensor that shows kWh consumed, but with no time period associated with it. Resets when device restarted and reflashed.
   hide_energy_sensor: "true"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -158,23 +161,6 @@ sensor:
     id: uptime_sensor
     entity_category: diagnostic
     internal: true
-
-  # Reports the WiFi signal strength/RSSI in dB
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: diagnostic
-
-  # Reports the WiFi signal strength in %
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "%"
-    entity_category: diagnostic
-    device_class: ""
 
   - platform: cse7766
     current:
@@ -317,17 +303,6 @@ light:
       number: GPIO13
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -26,6 +26,9 @@ substitutions:
   # Hide the ENERGY sensor that shows kWh consumed, but with no time period associated with it. Resets when device restarted and reflashed.
   hide_energy_sensor: "false"
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
@@ -115,23 +118,6 @@ sensor:
     id: uptime_sensor
     entity_category: diagnostic
     internal: true
-
-  # Reports the WiFi signal strength/RSSI in dB
-  - platform: wifi_signal
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: diagnostic
-
-  # Reports the WiFi signal strength in %
-  - platform: copy
-    source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "%"
-    entity_category: diagnostic
-    device_class: ""
 
   - platform: cse7766
     current:
@@ -260,17 +246,6 @@ light:
       number: GPIO13
 
 text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "Connected SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "Mac Address"
-      entity_category: diagnostic
-
   #  Creates a sensor showing when the device was last restarted
   - platform: template
     name: 'Last Restart'

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -8,6 +8,9 @@ substitutions:
   led_rgb_order: GRB
   led_chipset: WS2811
 
+packages:
+  wifi_sensors: !include common/wifi_sensors.yaml
+
 esphome:
   name: "${device_name}"
   friendly_name: ""
@@ -74,10 +77,6 @@ sensor:
   - platform: uptime
     name: "Uptime Sensor"
 
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-
 button:
   - platform: factory_reset
     name: "Reset"
@@ -100,15 +99,6 @@ light:
       - addressable_rainbow:
       - addressable_scan:
 
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-    ssid:
-      name: "Connected SSID"
-    mac_address:
-      name: "Mac Address"
-     
 time:
   - platform: sntp
     id: sntp_time

--- a/common/wifi_sensors.yaml
+++ b/common/wifi_sensors.yaml
@@ -1,4 +1,4 @@
-sensors:
+sensor:
   # Reports the WiFi signal strength/RSSI in dB
   - platform: wifi_signal
     name: "WiFi Signal dB"

--- a/common/wifi_sensors.yaml
+++ b/common/wifi_sensors.yaml
@@ -1,0 +1,29 @@
+sensors:
+  # Reports the WiFi signal strength/RSSI in dB
+  - platform: wifi_signal
+    name: "WiFi Signal dB"
+    id: wifi_signal_db
+    update_interval: 60s
+    entity_category: "diagnostic"
+
+  # Reports the WiFi signal strength in %
+  - platform: copy
+    source_id: wifi_signal_db
+    name: "WiFi Signal Percent"
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "Signal %"
+    entity_category: "diagnostic"
+    device_class: ""
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      entity_category: diagnostic
+    ssid:
+      name: "Connected SSID"
+      entity_category: diagnostic
+    mac_address:
+      name: "Mac Address"
+      entity_category: diagnostic


### PR DESCRIPTION
This is part of a potential series. Filing this one in particular as a RFC, to see how much appetite there might be to merge more.
Note, my longer-term goal is to rewrite the cse7766 sensor section and other similar sensors to be more circumspect in their update intervals.
e.g. with my Aeotec ZWave sockets, they are configurable to update different sensors at different intervals, but also update sooner for significant variances in power consumption [or for a temperature sensor, significant temperate change, etc].
But in order to not have to do the same changes multiple times, an inclusion pattern seems appropriate.