### PR TITLE
add id to cse7766/hlw8012 sensor entries, so they can be overridden

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -187,6 +187,7 @@ sensor:
     device_class: ""
 
   - platform: cse7766
+    id: athom_cse7766
     current:
       name: "Current"
       filters:

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -180,6 +180,7 @@ sensor:
     device_class: ""
 
   - platform: hlw8012
+    id: athom_hlw8012
     sel_pin:
       number: GPIO12
       inverted: True

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -177,6 +177,7 @@ sensor:
     device_class: ""
 
   - platform: cse7766
+    id: athom_cse7766
     current:
       name: "Current"
       filters:

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -134,6 +134,7 @@ sensor:
     device_class: ""
 
   - platform: cse7766
+    id: athom_cse7766
     current:
       name: "Current"
       filters:


### PR DESCRIPTION
this is related to #115. it should be generally harmless, but allow overrides to be placed on the sensor entries.