### PR TITLE
Add missing id fields to entities

### DIFF
--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -134,6 +134,7 @@ dashboard_import:
 binary_sensor:
   - platform: status
     name: "Status"
+    id: status_sensor
     entity_category: diagnostic
 
 sensor:
@@ -152,6 +153,7 @@ sensor:
   - platform: copy
     source_id: wifi_signal_db
     name: "WiFi Signal Percent"
+    id: wifi_signal_percent
     filters:
       - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
     unit_of_measurement: "Signal %"
@@ -161,6 +163,7 @@ sensor:
 button:
   - platform: restart
     name: "Restart"
+    id: restart_button
     entity_category: config
 
   - platform: factory_reset
@@ -171,6 +174,7 @@ button:
   - platform: safe_mode
     name: "Safe Mode"
     internal: false
+    id: safe_mode_button
     entity_category: config
 
 output:
@@ -224,12 +228,15 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      id: ip_address_sensor
       entity_category: diagnostic
     ssid:
       name: "Connected SSID"
+      id: connected_ssid_sensor
       entity_category: diagnostic
     mac_address:
       name: "Mac Address"
+      id: mac_address_sensor
       entity_category: diagnostic
 
   #  Creates a sensor showing when the device was last restarted
@@ -243,6 +250,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: template
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     lambda: |-
       int seconds = (id(uptime_sensor).state);

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -250,7 +250,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: template
     name: "Uptime"
-    id: uptime_sensor
+    id: uptime_template_sensor
     entity_category: diagnostic
     lambda: |-
       int seconds = (id(uptime_sensor).state);

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom RGBCCT Bulb"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.3"
+  project_version: "v1.1.4"
    # Restore the light (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_ON
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)


### PR DESCRIPTION
A few entities are missing an `id` field.
Useful for users who which to import this as a package and extend or remove entities.
I did my best to follow a naming convention.
Existing `id` fields were not refactored as to not break backward compatibility.

Upped version