### PR TITLE
Update dns_domain: from "" to ".local"

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.CB02 Relay Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
    # Restore the relay (GPO switch) upon reboot to state:
   relay_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)

--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -14,7 +14,7 @@ substitutions:
    # Restore the relay (GPO switch) upon reboot to state:
   relay_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom Garage Door Opener"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.2.2"
+  project_version: "v1.2.3"
   # Status inverted
   status_inverted: "true"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -14,7 +14,7 @@ substitutions:
   # Status inverted
   status_inverted: "true"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Mini Relay Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
    # Restore the relay (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -10,9 +10,9 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom Presence Sensor"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.2"
+  project_version: "v1.0.3"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom 1CH Relay Board"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.2"
+  project_version: "v1.0.3"
    # Restore the relay (GPO switch) upon reboot to state:
   relay_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -10,12 +10,12 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom 2CH Relay Board"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.2"
+  project_version: "v1.0.3"
    # Restore the relay (GPO switch) upon reboot to state:
   relay1_restore_mode: RESTORE_DEFAULT_OFF
   relay2_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -10,14 +10,14 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom 4CH Relay Board"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.2"
+  project_version: "v1.0.3"
    # Restore the relay (GPO switch) upon reboot to state:
   relay1_restore_mode: RESTORE_DEFAULT_OFF
   relay2_restore_mode: RESTORE_DEFAULT_OFF
   relay3_restore_mode: RESTORE_DEFAULT_OFF
   relay4_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -10,7 +10,7 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom 8CH Relay Board"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.0.2"
+  project_version: "v1.0.3"
    # Restore the relay (GPO switch) upon reboot to state:
   relay1_restore_mode: RESTORE_DEFAULT_OFF
   relay2_restore_mode: RESTORE_DEFAULT_OFF
@@ -21,7 +21,7 @@ substitutions:
   relay7_restore_mode: RESTORE_DEFAULT_OFF
   relay8_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom RGB Controller"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
    # Restore the light (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom RGBCCT Bulb"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
    # Restore the light (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_ON
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.RGBW Light Strip Controller"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
    # Restore the light (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_ON
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.Athom RGBCW Bulb"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
    # Restore the light (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_ON
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -11,7 +11,7 @@ substitutions:
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
   current_limit : "16"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -6,13 +6,13 @@ substitutions:
   room: ""
   device_description: "athom smart plug"
   project_name: "Athom Technology.Smart Plug"
-  project_version: "v1.0.2"
+  project_version: "v1.0.3"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   sensor_update_interval: 10s
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
   current_limit : "10"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.1Gang Switch V2"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -10,11 +10,11 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.1Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -10,12 +10,12 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.2Gang Switch V2"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -10,12 +10,12 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.2Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -10,13 +10,13 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.3Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
   # Restore the relay (GPO switch) upon reboot to state:
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
   light3_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -10,14 +10,14 @@ substitutions:
   # Project Name
   project_name: "Athom Technology.4Gang Switch"
   # Projection version denotes the release version of the yaml file, allowing checking of deployed vs latest version
-  project_version: "v1.1.2"
+  project_version: "v1.1.3"
    # Restore the relay (GPO switch) upon reboot to state:
   light1_restore_mode: RESTORE_DEFAULT_OFF
   light2_restore_mode: RESTORE_DEFAULT_OFF
   light3_restore_mode: RESTORE_DEFAULT_OFF
   light4_restore_mode: RESTORE_DEFAULT_OFF
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -5,13 +5,13 @@ substitutions:
   room: ""
   device_description: "athom wall outlet"
   project_name: "Athom Technology.Athom Wall Outlet"
-  project_version: "v1.1.3"
+  project_version: "v1.1.4"
   sensor_update_interval: "10s"
   relay_restore_mode: RESTORE_DEFAULT_OFF
   # Current Limit in Amps. AU Plug = 10. IL, BR, EU, UK, US Plug = 16.
   current_limit : "16"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -5,10 +5,10 @@ substitutions:
   room: ""
   device_description: "athom esp8285 without relay plug"
   project_name: "Athom Technology.Athom Without Relay Plug"
-  project_version: "v2.0.6"
+  project_version: "v2.0.7"
   sensor_update_interval: "10s"
   # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
-  dns_domain: ""
+  dns_domain: ".local"
   # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
   timezone: ""
   # Set the duration between the sntp service polling ntp.org servers for an update


### PR DESCRIPTION
This is following reports that the default ESPHome behaviour of publishing the device DNS name as <device-name>.local was not working in recent updates. To rectify this the substitution of dns_domain: ""  has been updated to force this behaviour, whilst allowing users to modify the substitution themselves if needed, with the change to dns_domain: ".local"


See: https://github.com/athom-tech/athom-configs/issues/111