### PR TITLE
Add ids to sensors that users might want to remove

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -271,6 +271,7 @@ sensor:
     update_interval: ${sensor_update_interval}
 
   - platform: total_daily_energy
+    id: daily_energy_sensor
     name: "Total Energy Since Boot"
     restore: true
     power_id: power_sensor
@@ -370,6 +371,7 @@ text_sensor:
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: template
+    id: uptime_text
     name: "Uptime"
     entity_category: diagnostic
     lambda: |-


### PR DESCRIPTION
Since ESPHome 2025.5.1 the firmware no longer fits two versions (one compressed) in 1MB flash. This makes OTA updates difficult, as an intermediate minimal firmware must be flashed. A possible workaround is to trim the config from unneeded features, so it's again ~0.5MB. What's unneeded can be decided users, if configs using this package can remove optional sensors by id.