### PR TITLE
ESP8285 Products - Specify  2MB Memory

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -40,6 +40,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -43,6 +43,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -37,6 +37,9 @@ esphome:
   area: "${room}"
   name_add_mac_suffix: true
   min_version: 2024.6.0
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   project:
     name: "${project_name}"
     version: "${project_version}"

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -40,6 +40,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   project:
     name: "${project_name}"
     version: "${project_version}"

--- a/athom-ls-4p-3wire.yaml
+++ b/athom-ls-4p-3wire.yaml
@@ -13,6 +13,9 @@ esphome:
   friendly_name: ""
   name_add_mac_suffix: true
   min_version: 2024.6.0
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   project:
     name: "${project_name}"
     version: "${project_version}"

--- a/athom-ls-4p-3wire.yaml
+++ b/athom-ls-4p-3wire.yaml
@@ -16,6 +16,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   project:
     name: "${project_name}"
     version: "${project_version}"

--- a/athom-ls-4p-4wire.yaml
+++ b/athom-ls-4p-4wire.yaml
@@ -16,6 +16,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-ls-4p-4wire.yaml
+++ b/athom-ls-4p-4wire.yaml
@@ -19,6 +19,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -40,6 +40,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -43,6 +43,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -41,6 +41,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -38,6 +38,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -40,6 +40,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -43,6 +43,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -44,6 +44,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -41,6 +41,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -43,6 +43,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -46,6 +46,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -47,6 +47,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -50,6 +50,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -40,6 +40,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -43,6 +43,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -69,6 +69,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
       then:
         - script.execute: fast_boot_script

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -66,6 +66,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
       then:
         - script.execute: fast_boot_script

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -44,6 +44,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -41,6 +41,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -69,6 +69,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
       then:
         - script.execute: fast_boot_script

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -66,6 +66,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
       then:
         - script.execute: fast_boot_script

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -49,6 +49,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -46,6 +46,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -44,6 +44,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -47,6 +47,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -40,6 +40,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -43,6 +43,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -40,6 +40,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -43,6 +43,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -41,6 +41,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -44,6 +44,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -41,6 +41,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -44,6 +44,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -45,6 +45,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -42,6 +42,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -46,6 +46,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -43,6 +43,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -39,6 +39,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
   on_boot:
     - priority: 600
       then:

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -42,6 +42,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
   on_boot:
     - priority: 600
       then:

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -39,6 +39,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
  
 esp8266:
   board: esp8285

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -36,6 +36,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
  
 esp8266:
   board: esp8285

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -16,6 +16,9 @@ esphome:
   project:
     name: "${project_name}"
     version: "${project_version}"
+  platformio_options:
+    board_upload.flash_size: 2MB
+    board_upload.maximum_size: 2097152
 
 esp8266:
   board: esp8285

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -19,6 +19,7 @@ esphome:
   platformio_options:
     board_upload.flash_size: 2MB
     board_upload.maximum_size: 2097152
+    board_build.ldscript: eagle.flash.2m.ld
 
 esp8266:
   board: esp8285


### PR DESCRIPTION
As it has come to light that all Athom ESP8285 microcontrollers used are a model that provides 2MB memory, yet the yaml configs never used this. This PULL is to remedy this situation.
