### PR TITLE
Replace custom uptime lambda with built-in uptime text_sensor platform

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -224,7 +224,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -149,12 +149,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -226,29 +220,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -80,12 +80,6 @@ dashboard_import:
   package_import_url: github://athom-tech/athom-configs/athom-garage-door.yaml
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -213,29 +207,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -211,7 +211,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -252,7 +252,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -165,12 +165,6 @@ light:
       - light.turn_off: led
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -254,29 +248,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -174,12 +174,6 @@ binary_sensor:
       }
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -432,29 +426,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -430,7 +430,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -160,7 +160,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -89,12 +89,6 @@ binary_sensor:
     entity_category: diagnostic
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -162,29 +156,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -90,12 +90,6 @@ binary_sensor:
     entity_category: diagnostic
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -169,29 +163,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -167,7 +167,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -180,7 +180,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -92,12 +92,6 @@ binary_sensor:
     entity_category: diagnostic
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -182,29 +176,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -208,7 +208,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -96,12 +96,6 @@ binary_sensor:
     entity_category: diagnostic
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -210,29 +204,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -107,12 +107,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -184,29 +178,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -182,7 +182,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -141,12 +141,6 @@ binary_sensor:
     entity_category: diagnostic
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -245,29 +239,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -243,7 +243,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -187,7 +187,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -105,12 +105,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -189,29 +183,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -237,7 +237,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -141,12 +141,6 @@ binary_sensor:
     entity_category: diagnostic
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -239,29 +233,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -373,7 +373,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -174,12 +174,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   # Reports the WiFi signal strength/RSSI in dB
   - platform: wifi_signal
     name: "WiFi Signal dB"
@@ -375,29 +369,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -387,7 +387,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -167,12 +167,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: True
-
   # Reports the WiFi signal strength/RSSI in dB
   - platform: wifi_signal
     name: "WiFi Signal dB"
@@ -389,29 +383,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -247,7 +247,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -153,12 +153,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -249,29 +243,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -247,7 +247,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -153,12 +153,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -249,29 +243,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -293,7 +293,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -171,12 +171,6 @@ binary_sensor:
         - light.toggle: light2
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -295,29 +289,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -171,12 +171,6 @@ binary_sensor:
         - light.toggle: light2
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -290,29 +284,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -288,7 +288,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -189,12 +189,6 @@ binary_sensor:
         - light.toggle: light3
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -331,29 +325,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -329,7 +329,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -291,7 +291,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -191,12 +191,6 @@ binary_sensor:
         - light.toggle: light4
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   - platform: wifi_signal
     name: "WiFi Signal dB"
     id: wifi_signal_db
@@ -293,29 +287,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -340,7 +340,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -157,12 +157,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   # Reports the WiFi signal strength/RSSI in dB
   - platform: wifi_signal
     name: "WiFi Signal dB"
@@ -342,29 +336,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -114,12 +114,6 @@ binary_sensor:
           - button.press: Reset
 
 sensor:
-  - platform: uptime
-    name: "Uptime Sensor"
-    id: uptime_sensor
-    entity_category: diagnostic
-    internal: true
-
   # Reports the WiFi signal strength/RSSI in dB
   - platform: wifi_signal
     name: "WiFi Signal dB"
@@ -285,29 +279,13 @@ text_sensor:
 #    device_class: timestamp
 
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
-  - platform: template
+  - platform: uptime
     name: "Uptime"
     entity_category: diagnostic
-    lambda: |-
-      int seconds = (id(uptime_sensor).state);
-      int days = seconds / (24 * 3600);
-      seconds = seconds % (24 * 3600);
-      int hours = seconds / 3600;
-      seconds = seconds % 3600;
-      int minutes = seconds /  60;
-      seconds = seconds % 60;
-      if ( days > 3650 ) {
-        return { "Starting up" };
-      } else if ( days ) {
-        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( hours ) {
-        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else if ( minutes ) {
-        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
-      } else {
-        return { (String(seconds) +"s").c_str() };
-      }
     icon: mdi:clock-start
+    update_interval: 15s
+    format:
+      separator: " "
 
 time:
   - platform: sntp

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -283,7 +283,7 @@ text_sensor:
     name: "Uptime"
     entity_category: diagnostic
     icon: mdi:clock-start
-    update_interval: 15s
+    update_interval: 60s
     format:
       separator: " "
 


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `text_sensor` template + lambda that formats uptime as `"1d 2h 3m 4s"` with ESPHome's built-in `text_sensor` / `platform: uptime` across 22 device configs. Also removes the now-unused internal numeric `uptime_sensor` (it only existed to feed the lambda).

This is the same change #143 was trying to achieve by porting the Arduino `String` calls to `std::to_string` for ESP-IDF compatibility — but instead of maintaining a lambda per device, it hands the problem to ESPHome core, which already solved it in 2024 (see [text_sensor uptime docs](https://esphome.io/components/text_sensor/uptime.html)).

Follow-up from the discussion on #143: https://github.com/athom-tech/athom-configs/pull/143#issuecomment-3568636957

## Why

- **Fixes the 2026.1.0 breakage at the root.** The lambda relies on Arduino `String`, which is why #143 is needed; the built-in platform uses `std::string` and has no framework-specific code paths.

- **No heap churn on the device.** This is the big one on ESP8266.

  The old `text_sensor: platform: template` block had no `update_interval` set, so it used the template text_sensor default (`cv.polling_component_schema("60s")`): the lambda ran **every 60 seconds**, whether or not the displayed value actually changed.

  Each run allocates on the heap. Walking through the `days > 0` branch — the one that's hit for any device that has been up for at least a day, i.e. the steady-state case:

  ```cpp
  return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
  ```

  - 4× `String(int)` constructors → 4 allocations
  - 7× `operator+` temporaries (each `+` produces a fresh `String` with its own malloc'd buffer) → 7 allocations
  - `.c_str()` then the `std::string` wrapping in `return { ... }` → 1 more (the final string is ~12+ chars once past `"1d 0h 0m 0s"`, which exceeds Arduino's SSO threshold)

  **≈12 heap allocations per 60s run**, each of a different size, plus the matching `free()`s as the temporaries die. That's:

  - ~17,280 malloc/free pairs per day per device
  - ~6.3 million per year per device

  Variable-size allocations at that rate are the textbook worst case for heap fragmentation. On an ESP8266, whose heap is shared with Wi-Fi, LWIP and the rest of the app, this is exactly how long-uptime devices start failing to allocate Wi-Fi buffers and rebooting. Other branches are cheaper — `hours` branch ~9 allocs, `minutes` ~6, `else` ~3 — but the days branch dominates because it's the steady state for any device that's been up more than a day.

  The built-in `text_sensor: platform: uptime` formats into a fixed 256-byte stack buffer with `buf_append_printf` and publishes a single `std::string` sized to the final length. **Zero heap allocations per update**, no temporaries, no fragmentation.

  **Measured on an Athom RGBCCT bulb (ESP8266)** shortly after boot:
  - Free heap before: **38,624 bytes**
  - Free heap after:  **38,712 bytes**
  - Δ: **+88 bytes free** immediately (one fewer sensor component instance). The bigger win isn't that number — it's the elimination of 17k allocations/day of varying sizes, which is what preserves the *largest contiguous* free block over long uptimes. Peak free heap moves by tens of bytes; resistance to fragmentation-induced reboots is the actual payoff.

- **No more recorder churn in Home Assistant.** The old format always included seconds (`"1d 2h 3m 4s"`), so the entity's state changed on every single poll and HA's recorder wrote a row to the `states` / `states_meta` tables for each one. That's ~1,440 rows per device per day of uptime noise — pure garbage data that only exists because the string happened to differ by one character. With seconds omitted, the state only changes at minute/hour/day boundaries, which is what a human actually wants to see in the history graph anyway.

- **Removes ~26 lines of per-device string-building code** in favour of one declarative block.

- **Less to maintain** — ESPHome core tests and maintains the formatter.

## Format and cadence

- `update_interval: 60s` matches the original template text_sensor's default cadence, so the user-visible refresh rate is unchanged.
- `format.separator: " "` keeps the space between units (`"1d 2h 3m"`, not `"1d2h3m"`).

At `update_interval: 60s`, the built-in suppresses the seconds field (seconds are only shown when the update interval is `< 30s`, since a seconds value that only refreshes once a minute would jitter). So user-visible strings go from `"1d 2h 3m 4s"` to `"1d 2h 3m"`. That seconds value was always stale by up to a minute anyway — the numeric sensor only updated the state every 60s and the lambda read that state — so removing it doesn't hide information that was actually accurate. Smaller values behave the same way: `"3m"` instead of `"3m 45s"`, `"45s"` becomes `"1m"` once `minutes > 0`.

One other behaviour difference: the old lambda returned the string `"Starting up"` when `days > 3650`, which was a guard against the numeric `uptime_sensor` reporting garbage before its first update. The built-in platform reads `millis_64()` directly and can't hit that state, so the guard is unnecessary and that specific string is no longer produced.

## Files touched

22 YAMLs updated (all configs that used the `uptime_sensor` + lambda pair). The 3 configs that only had the raw numeric `platform: uptime` sensor (`athom-ls-4p-3wire.yaml`, `athom-ls-4p-4wire.yaml`, `athom-ws2812b.yaml`) are unchanged.

## Test plan

Tested on a real Athom RGBCCT bulb (ESP8266) by pointing a personal device YAML at this PR branch:

```yaml
# athom-rgbct-light-0e9d69.yaml
substitutions:
  name: athom-rgbct-light-0e9d69
packages:
  athom.rgbct-light: github://bdraco/athom-configs/athom-rgbct-light.yaml@use-builtin-uptime-text-sensor
esphome:
  name: ${name}
  name_add_mac_suffix: false
api:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

- [x] `esphome config athom-rgbct-light-0e9d69.yaml` validates — resolved `text_sensor` shows `platform: uptime` with `separator: ' '`, `days: d`, `hours: h`, `minutes: m`, `seconds: s`, `icon: mdi:clock-start`, and the internal numeric `uptime_sensor` is gone.
- [x] Flashed the bulb from this branch; Home Assistant's `Uptime` entity updates with the expected format.
- [x] Free heap: 38,624 → 38,712 (+88 bytes, immediately post-boot).
- [x] `Uptime Sensor` numeric entity is gone from HA (was `internal: true`, so no user-visible change).
- [x] Build matrix on fork (22 files × stable/beta/dev) — https://github.com/bdraco/athom-configs/pull/1

## Relationship to #143

If this is merged, #143 becomes unnecessary (the lambda it's patching is deleted). Happy to close this in favour of #143 if the maintainers would rather keep the inline lambda per device for newbie readability.