### PR TITLE
Smart Plugs - Add "id: uptime_sensor" back to config

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -371,6 +371,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -385,6 +385,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s


### PR DESCRIPTION
Add back in the id: uptime_sensor that was deleted in the prior change to using ESPHome component to give uptime, removing prior lamdba method.