### PR TITLE
Add id to all uptime sensors for all configs

### DIFF
--- a/athom-cb02.yaml
+++ b/athom-cb02.yaml
@@ -222,6 +222,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -209,6 +209,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-ls-4p-3wire.yaml
+++ b/athom-ls-4p-3wire.yaml
@@ -73,7 +73,8 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "Uptime Sensor"
+    name: "Uptime"
+    id: uptime_sensor
 
   - platform: wifi_signal
     name: "WiFi Signal"

--- a/athom-ls-4p-4wire.yaml
+++ b/athom-ls-4p-4wire.yaml
@@ -73,7 +73,8 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "Uptime Sensor"
+    name: "Uptime"
+    id: uptime_sensor
 
   - platform: wifi_signal
     name: "WiFi Signal"

--- a/athom-mini-switch.yaml
+++ b/athom-mini-switch.yaml
@@ -250,6 +250,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-presence-sensor.yaml
+++ b/athom-presence-sensor.yaml
@@ -428,6 +428,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-relay-board-x1.yaml
+++ b/athom-relay-board-x1.yaml
@@ -158,6 +158,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-relay-board-x2.yaml
+++ b/athom-relay-board-x2.yaml
@@ -165,6 +165,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-relay-board-x4.yaml
+++ b/athom-relay-board-x4.yaml
@@ -178,6 +178,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-relay-board-x8.yaml
+++ b/athom-relay-board-x8.yaml
@@ -206,6 +206,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-rgb-light.yaml
+++ b/athom-rgb-light.yaml
@@ -180,6 +180,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-rgbct-light.yaml
+++ b/athom-rgbct-light.yaml
@@ -241,6 +241,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-rgbw-light.yaml
+++ b/athom-rgbw-light.yaml
@@ -185,6 +185,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-rgbww-light.yaml
+++ b/athom-rgbww-light.yaml
@@ -235,6 +235,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -371,6 +371,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-smart-plug.yaml
+++ b/athom-smart-plug.yaml
@@ -385,6 +385,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-sw01-v2.yaml
+++ b/athom-sw01-v2.yaml
@@ -245,6 +245,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-sw01.yaml
+++ b/athom-sw01.yaml
@@ -245,6 +245,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-sw02-v2.yaml
+++ b/athom-sw02-v2.yaml
@@ -291,6 +291,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-sw02.yaml
+++ b/athom-sw02.yaml
@@ -286,6 +286,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-sw03.yaml
+++ b/athom-sw03.yaml
@@ -327,6 +327,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-sw04.yaml
+++ b/athom-sw04.yaml
@@ -289,6 +289,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-wall-outlet.yaml
+++ b/athom-wall-outlet.yaml
@@ -338,6 +338,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-without-relay-plug.yaml
+++ b/athom-without-relay-plug.yaml
@@ -281,6 +281,7 @@ text_sensor:
   #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
   - platform: uptime
     name: "Uptime"
+    id: uptime_sensor
     entity_category: diagnostic
     icon: mdi:clock-start
     update_interval: 60s

--- a/athom-ws2812b.yaml
+++ b/athom-ws2812b.yaml
@@ -76,7 +76,8 @@ binary_sensor:
 
 sensor:
   - platform: uptime
-    name: "Uptime Sensor"
+    name: "Uptime"
+    id: uptime_sensor
 
   - platform: wifi_signal
     name: "WiFi Signal"


### PR DESCRIPTION
This pull request returns the `id: uptime_sensor` for all configs.

Extends the PR, which becomes obsolete: https://github.com/athom-tech/athom-configs/pull/151