### PR TITLE
Disable option not available on ESP8266

### DIFF
--- a/athom-ir-remote.yaml
+++ b/athom-ir-remote.yaml
@@ -119,7 +119,6 @@ remote_transmitter:
   pin:
     number: GPIO4
   carrier_duty_percent: 50%                   # Standard 50% duty cycle for 38kHz IR carrier
-  non_blocking: true                          # IR TX runs without stalling the main loop
 
 # Receives and decodes incoming IR signals. dump: all logs every received code
 # regardless of protocol — useful during manual code capture sessions.


### PR DESCRIPTION
This `non_blocking: true` option was causing the build to fail for ESP8266, which is what this device is built with anyway.
I assume this was a copy/paste error when back-porting changes from the ESP32 based device.