### PR TITLE
Exclude ws2812b and ls-4p-3wire/4wire configs from builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          mapfile -t files < <(find . -maxdepth 1 -type f -name '*.yaml' -exec basename {} .yaml \; | sort)
+          mapfile -t files < <(find . -maxdepth 1 -type f -name '*.yaml' \
+            ! -name 'athom-ws2812b.yaml' \
+            ! -name 'athom-ls-4p-3wire.yaml' \
+            ! -name 'athom-ls-4p-4wire.yaml' \
+            -exec basename {} .yaml \; | sort)
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No root-level ESPHome YAML files found." >&2
             exit 1

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -97,7 +97,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          mapfile -t files < <(find . -maxdepth 1 -type f -name '*.yaml' -exec basename {} \; | sort)
+          mapfile -t files < <(find . -maxdepth 1 -type f -name '*.yaml' \
+            ! -name 'athom-ws2812b.yaml' \
+            ! -name 'athom-ls-4p-3wire.yaml' \
+            ! -name 'athom-ls-4p-4wire.yaml' \
+            -exec basename {} \; | sort)
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No root-level ESPHome YAML files found." >&2
             exit 1


### PR DESCRIPTION
Add ! -name filters to the YAML discovery step in both build workflows so athom-ws2812b.yaml, athom-ls-4p-3wire.yaml and athom-ls-4p-4wire.yaml are no longer compiled by CI or published as firmware.